### PR TITLE
phase1: v0.18.0 — provenance manifest, Horizons CI, reliability, observability

### DIFF
--- a/.github/workflows/horizons.yml
+++ b/.github/workflows/horizons.yml
@@ -1,0 +1,46 @@
+name: horizons-regression
+
+on:
+  pull_request:
+    paths:
+      - crates/astro-core/**
+      - crates/astro-vedic/**
+      - crates/astro-api/**
+      - tests/golden/horizons_stations/**
+      - tests/regression/**
+      - .github/workflows/horizons.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  ASTRO_EPHE_PATH: ./ephe/de440.bsp
+
+jobs:
+  horizons-regression:
+    name: horizons-regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Authenticate to Google Cloud
+        if: ${{ vars.GCP_PROJECT_ID != '' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.GCP_DEPLOY_SERVICE_ACCOUNT != '' }}
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+      - name: Set up gcloud
+        if: ${{ vars.GCP_PROJECT_ID != '' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.GCP_DEPLOY_SERVICE_ACCOUNT != '' }}
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Fetch DE440 kernel
+        if: ${{ vars.GCP_PROJECT_ID != '' && secrets.GCP_WORKLOAD_IDENTITY_PROVIDER != '' && secrets.GCP_DEPLOY_SERVICE_ACCOUNT != '' }}
+        run: |
+          mkdir -p ./ephe
+          gcloud storage cp gs://${{ vars.CLOUD_RUN_EPHEMERIS_BUCKET || 'daanyam-ephe' }}/de440.bsp "${ASTRO_EPHE_PATH}"
+      - name: Horizons station regressions
+        run: |
+          cargo test -p astro-core outer_planet_stations retrograde_motion_proptest -- --nocapture
+          cargo test -p astro-core de440_horizons_regression_vectors_match -- --nocapture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,80 @@
 # Changelog
 
+## 0.18.0
+
+### Added
+
+- Rich public `GET /provenance` manifest: `kernel_id`, `kernel_source`, `ayanamsa_id`, `ayanamsa_algorithm`, `ayanamsa_version`, `git_commit`, `build_date`, `tolerance_arcsec`, `validation_baseline`, `changelog_url`, `node_policy_id`, `supported_bodies` (additive; existing fields unchanged).
+- `Cache-Control: public, max-age=3600` on `/provenance` for CDN caching.
+- Compile-time build metadata via `crates/astro-api/build.rs` (`GIT_COMMIT`, `BUILD_DATE` env overrides for Docker/CI).
+- Phase 1 close artifacts: [docs/runbooks/phase1-checklist-evidence.md](docs/runbooks/phase1-checklist-evidence.md), [docs/retros/phase1.md](docs/retros/phase1.md).
+
+### Changed
+
+- `ENGINE_SEMANTIC_VERSION` aligned to `0.18.0` (was lagging changelog at `0.17.0`).
+
+### Migration note
+
+No breaking changes to `/chart/sidereal`, `/dasha`, or `/positions/*`. `/provenance` gains additive JSON fields only; clients may ignore new keys. Synthetic chart golden (`275.1573701670353°` lagna) unchanged.
+
+Tag release: `git tag -a v0.18.0 -m "Phase 1 close"` then `git push origin v0.18.0` (deploy via [.github/workflows/deploy.yml](.github/workflows/deploy.yml) on tag).
+
+## 0.17.4
+
+### Added
+
+- Horizons-vetted Jupiter and Saturn station-window fixtures: `tests/golden/horizons_stations/`, integration test `outer_planet_stations`, CI workflow `.github/workflows/horizons.yml`.
+- Centralized longitude motion and retrograde sign contract in `astro_core::motion` (epsilon `1e-12`); DE440 proptest `retrograde_motion_proptest`.
+
+### Changed
+
+- `astro-api` sidereal/chart motion now uses `astro_core::longitude_motion` as the single source of truth for speed and retrograde flags.
+
+### Deferred
+
+- Uranus, Neptune, Pluto station regressions — [docs/adr/0004-outer-planets-deferred.md](docs/adr/0004-outer-planets-deferred.md).
+
+### Migration note
+
+No HTTP JSON schema changes for `/chart/sidereal`, `/dasha`, or `/positions/*`. Operators should ensure PRs touching motion paths run the `horizons-regression` workflow (DE440 kernel required).
+
+## 0.17.3
+
+### Added
+
+- Production reliability: `minScale: "1"` aligned on [deploy/cloud_run.yaml](deploy/cloud_run.yaml) (canonical CI path already used [deploy/cloudrun/service.yaml](deploy/cloudrun/service.yaml)).
+- Synthetic chart monitor: [tests/golden/synthetic/delhi-1990-chart.json](tests/golden/synthetic/delhi-1990-chart.json), [scripts/monitoring/synthetic-chart-sidereal.sh](scripts/monitoring/synthetic-chart-sidereal.sh), CI test `synthetic_chart_golden`.
+- Multi-region uptime setup (60s, 2 consecutive failures) in [deploy/cloudrun/setup_monitoring.sh](deploy/cloudrun/setup_monitoring.sh); runbooks [docs/runbooks/oncall.md](docs/runbooks/oncall.md), [docs/runbooks/reliability-min-instances.md](docs/runbooks/reliability-min-instances.md), [docs/perf/baseline-w4.md](docs/perf/baseline-w4.md).
+
+### Migration note
+
+No HTTP JSON schema changes for `/chart/sidereal`, `/dasha`, or `/positions/*`. Operators should confirm `METRICS_TOKEN` on Cloud Run, run W4 load baseline after min-instances deploy, and wire synthetic chart checks (5 min) plus PagerDuty via `NOTIFICATION_CHANNELS`.
+
+## 0.17.2
+
+### Added
+
+- Structured `slo_breach` log events when successful `POST /chart/sidereal` exceeds 200 ms or `POST /dasha` exceeds 300 ms (paired `request_id` with `api_usage`).
+- Observability runbook and BigQuery query templates: `docs/runbooks/observability.md`, `docs/runbooks/queries/latency_p95.sql`.
+- Optional idempotent log-sink helper: `scripts/gcp/create-log-sink.sh`.
+
+### Migration note
+
+No HTTP JSON schema changes for `/chart/sidereal`, `/dasha`, or `/positions/*`. Webapp clients should send `X-Request-Id: <uuidv4>` on every engine call; operators can wire Cloud Logging → BigQuery per the observability runbook.
+
+## 0.17.1
+
+### Added
+
+- Structured `api_usage` request logs now include `engine_version` and `kernel_hash` for deploy correlation.
+- `GET /metrics` Prometheus scrape endpoint, protected by `METRICS_TOKEN` bearer auth (returns 503 when unset).
+- Perf baseline and cold-start documentation under `docs/perf/` (`baseline-w2.md`, `cold-start-w2.md`).
+- Load-test helper script `scripts/load/baseline-chart-sidereal.sh`.
+
+### Migration note
+
+No HTTP JSON schema changes for `/chart/sidereal`, `/dasha`, or `/positions/*`. Operators should set `METRICS_TOKEN` on Cloud Run before scraping; update Prometheus configs to send `Authorization: Bearer`.
+
 ## 0.17.0
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,8 @@ dependencies = [
  "astro-vedic",
  "axum",
  "chrono",
+ "metrics",
+ "metrics-exporter-prometheus",
  "reqwest",
  "serde",
  "serde_json",
@@ -65,6 +67,7 @@ dependencies = [
  "chrono-tz",
  "criterion",
  "percent-encoding",
+ "proptest",
  "reqwest",
  "serde",
  "serde_json",
@@ -137,6 +140,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +223,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +277,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -329,12 +371,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -387,6 +448,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,10 +528,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -467,6 +571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +590,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -547,6 +663,25 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -642,6 +777,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -663,6 +799,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -881,6 +1018,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +1062,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1096,53 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1040,6 +1240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1274,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1105,6 +1317,46 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -1212,6 +1464,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,17 +1587,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1328,6 +1642,7 @@ version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1338,6 +1653,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1352,6 +1679,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1450,6 +1809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1877,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1626,6 +2004,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +2096,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +2159,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -1925,6 +2331,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +2354,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ axum = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 criterion = { version = "0.5", default-features = false }
+metrics = "0.24"
+metrics-exporter-prometheus = "0.16"
 napi = { version = "2", default-features = false, features = ["napi8"] }
 napi-derive = "2"
 percent-encoding = "2"
@@ -35,6 +37,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace"] }
 uuid = { version = "1", features = ["v4"] }
 wasm-bindgen = "0.2"
+proptest = "1"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM rust:1.85-bookworm AS builder
 WORKDIR /app
 
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV BUILD_DATE=${BUILD_DATE}
+
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 COPY tests ./tests
@@ -8,7 +13,8 @@ COPY docs ./docs
 COPY benches ./benches
 COPY README.md RELEASE.md rustfmt.toml ./
 
-RUN cargo build -p astro-api --release
+RUN BUILD_DATE="${BUILD_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" \
+    cargo build -p astro-api --release
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ PR automation lives in [`.github/workflows/ci.yml`](/Users/sanjeet/Desktop/daany
 
 ## Current status
 
-This sprint delivers the workspace skeleton, initial contracts/utilities, the DE440 apparent-position pipeline for the current graha set, the first Lahiri sidereal slice, API routes, tests, and CI skeleton. Unsupported precision-sensitive features still fail explicitly rather than silently falling back.
+Phase 1 engineering track closes at **v0.18.0**. The HTTP API serves Lahiri sidereal positions, charts, dasha, and a public provenance manifest.
+
+- **Live provenance:** `GET /provenance` (unauthenticated, `Cache-Control: public, max-age=3600`) — kernel, ayanamsa algorithm, build metadata, validation baseline, supported bodies.
+- **Phase 1 retrospective:** [docs/retros/phase1.md](docs/retros/phase1.md)
+- **Checklist evidence:** [docs/runbooks/phase1-checklist-evidence.md](docs/runbooks/phase1-checklist-evidence.md)
+
+Unsupported precision-sensitive features still fail explicitly rather than silently falling back.
 
 ## DE440 ephemeris file
 
@@ -92,7 +98,7 @@ Regression fixtures in [tests/regression/manifest.json](/Users/sanjeet/Documents
 The dedicated sidereal API route documents its JSON contract in [docs/api_positions_sidereal.md](/Users/sanjeet/Documents/Playground/docs/api_positions_sidereal.md). Lahiri provenance and versioning rules are documented in [docs/astronomy.md](/Users/sanjeet/Documents/Playground/docs/astronomy.md) and [CHANGELOG.md](/Users/sanjeet/Documents/Playground/CHANGELOG.md).
 The chart-oriented sidereal contract is documented in [docs/api_chart_sidereal.md](/Users/sanjeet/Documents/Playground/docs/api_chart_sidereal.md).
 Compact mobile sample payloads live in [docs/examples/mobile_chart_compact.json](/Users/sanjeet/Documents/Playground/docs/examples/mobile_chart_compact.json), [docs/examples/mobile_chart_compact_sidereal_only.json](/Users/sanjeet/Documents/Playground/docs/examples/mobile_chart_compact_sidereal_only.json), [docs/examples/mobile_positions_compact.json](/Users/sanjeet/Documents/Playground/docs/examples/mobile_positions_compact.json), and [docs/examples/mobile_positions_sidereal_compact_sidereal_only.json](/Users/sanjeet/Documents/Playground/docs/examples/mobile_positions_sidereal_compact_sidereal_only.json).
-The live OpenAPI 3.1 document is served from `/openapi.json`; interactive docs are at `/docs` (Redoc, same-origin spec). The release artifact is committed at [dist/openapi.json](/Users/sanjeet/Documents/Playground/dist/openapi.json).
+The live OpenAPI 3.1 document is served from `/openapi.json`; interactive docs are at `/docs` (Redoc, same-origin spec). The release artifact is committed at [dist/openapi.json](dist/openapi.json).
 Release candidate local run and packaging steps are documented in [RELEASE.md](/Users/sanjeet/Documents/Playground/RELEASE.md).
 Container and readiness guidance are documented in [docs/deploy.md](/Users/sanjeet/Documents/Playground/docs/deploy.md).
 Cross-route schema governance is documented in [docs/adr/0002-api-schema-versioning.md](/Users/sanjeet/Documents/Playground/docs/adr/0002-api-schema-versioning.md).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,21 @@
 # Release Candidate Runbook
 
+## v0.18.0 — Phase 1 close
+
+| Step | Action |
+|------|--------|
+| Version | `ENGINE_SEMANTIC_VERSION = "0.18.0"` in `crates/astro-api/src/lib.rs` |
+| Changelog | [CHANGELOG.md](CHANGELOG.md) `## 0.18.0` |
+| Verify | `export ASTRO_EPHE_PATH=./ephe/de440.bsp && cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` |
+| OpenAPI | `cargo run -p astro-api --bin write_openapi` → commit `dist/openapi.json` |
+| Tag | `git tag -a v0.18.0 -m "Phase 1 close"` |
+| Push tag | `git push origin v0.18.0` — triggers [.github/workflows/deploy.yml](.github/workflows/deploy.yml) |
+| Smoke | `curl -sS https://<cloud-run>/provenance \| jq` — expect extended manifest + `Cache-Control` |
+
+Docker build args (optional): `GIT_COMMIT`, `BUILD_DATE` (RFC3339 UTC) passed at image build for `/provenance` metadata.
+
+Evidence: [docs/runbooks/phase1-checklist-evidence.md](docs/runbooks/phase1-checklist-evidence.md). Retrospective: [docs/retros/phase1.md](docs/retros/phase1.md).
+
 ## Local API run
 
 1. Ensure the Rust toolchain is installed and available on `PATH`.

--- a/crates/astro-api/Cargo.toml
+++ b/crates/astro-api/Cargo.toml
@@ -4,11 +4,14 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+build = "build.rs"
 
 [dependencies]
 astro-core = { path = "../astro-core" }
 astro-vedic = { path = "../astro-vedic" }
 axum.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/astro-api/build.rs
+++ b/crates/astro-api/build.rs
@@ -1,0 +1,50 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=GIT_COMMIT");
+    println!("cargo:rerun-if-env-changed=BUILD_DATE");
+
+    let git_commit = std::env::var("GIT_COMMIT").unwrap_or_else(|_| {
+        std::process::Command::new("git")
+            .args(["rev-parse", "--short=12", "HEAD"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "unknown".to_string())
+    });
+    println!("cargo:rustc-env=GIT_COMMIT={git_commit}");
+
+    let build_date = std::env::var("BUILD_DATE").unwrap_or_else(|_| utc_rfc3339_now());
+    println!("cargo:rustc-env=BUILD_DATE={build_date}");
+}
+
+fn utc_rfc3339_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before UNIX_EPOCH")
+        .as_secs();
+    let days = secs / 86_400;
+    let time_of_day = secs % 86_400;
+    let (year, month, day) = civil_from_days(days as i64);
+    let hour = time_of_day / 3600;
+    let minute = (time_of_day % 3600) / 60;
+    let second = time_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+/// Gregorian civil date from days since 1970-01-01 (proleptic).
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + if m <= 2 { 1 } else { 0 };
+    (year as i32, m as u32, d as u32)
+}

--- a/crates/astro-api/src/lib.rs
+++ b/crates/astro-api/src/lib.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "256"]
 
+mod metrics;
+
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex},
@@ -22,7 +24,7 @@ use astro_vedic::{
 use axum::{
     body::{to_bytes, Body},
     extract::{Request, State},
-    http::{HeaderMap, HeaderValue, Method, StatusCode},
+    http::{header::CACHE_CONTROL, HeaderMap, HeaderValue, Method, StatusCode},
     middleware::{self, Next},
     response::{Html, IntoResponse, Response},
     routing::{get, post},
@@ -34,11 +36,18 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-pub const ENGINE_SEMANTIC_VERSION: &str = "0.17.0";
+pub const ENGINE_SEMANTIC_VERSION: &str = "0.18.0";
 pub const NODE_POLICY_ID: &str = "true_node_mean_ecliptic_of_date";
+pub const VALIDATION_BASELINE: &str = "JPL Horizons";
+/// Station-suite longitude tolerance: 1e-7° expressed in arcseconds.
+pub const PROVENANCE_TOLERANCE_ARCSEC: f64 = 0.00036;
+pub const DEFAULT_CHANGELOG_URL: &str =
+    "https://github.com/daanyam/astro-engine/blob/main/CHANGELOG.md";
+const BUILD_GIT_COMMIT: &str = env!("GIT_COMMIT");
+const BUILD_DATE_RFC3339: &str = env!("BUILD_DATE");
 pub const CHART_SIDEREAL_SCHEMA_VERSION: &str = "chart_sidereal_v1";
 pub const DASHA_SCHEMA_VERSION: &str = "dasha_v2";
-const RETROGRADE_DELTA_DAYS: f64 = 0.5;
+/// Inbound `X-Request-Id` is accepted when present; the same value is echoed on the response.
 const REQUEST_ID_HEADER: &str = "x-request-id";
 const CORRELATION_ID_HEADER: &str = "x-correlation-id";
 const TRACEPARENT_HEADER: &str = "traceparent";
@@ -49,6 +58,7 @@ const RETRY_AFTER_HEADER: &str = "retry-after";
 const API_KEY_HEADER: &str = "x-api-key";
 const AUTHORIZATION_HEADER: &str = "authorization";
 const API_KEY_LOG_PREFIX_CHARS: usize = 8;
+const METRICS_TOKEN_ENV_VAR: &str = "METRICS_TOKEN";
 
 /// Redoc UI loads the spec from the same origin (`GET /openapi.json`). The bundle is pinned for stable builds.
 const REDOC_STANDALONE_JS: &str =
@@ -88,6 +98,23 @@ impl ApiState {
         self.kernel_load_seconds = kernel_load_seconds;
         self
     }
+
+    pub fn engine_version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn kernel_hash(&self) -> &str {
+        &self.kernel_hash
+    }
+
+    pub fn kernel_load_seconds(&self) -> f64 {
+        self.kernel_load_seconds
+    }
+}
+
+/// Install the Prometheus recorder and set startup gauges from `state`.
+pub fn init_observability(state: &ApiState) {
+    metrics::init(state);
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -106,6 +133,80 @@ pub struct ProvenanceResponse {
     pub gravitational_deflection: bool,
     pub kernel_hash: String,
     pub kernel_load_seconds: f64,
+    pub kernel_id: String,
+    pub kernel_source: String,
+    pub ayanamsa_id: String,
+    pub ayanamsa_algorithm: String,
+    pub ayanamsa_version: String,
+    pub git_commit: String,
+    pub build_date: String,
+    pub tolerance_arcsec: f64,
+    pub validation_baseline: String,
+    pub changelog_url: String,
+    pub node_policy_id: String,
+    pub supported_bodies: Vec<CelestialBody>,
+}
+
+pub fn supported_celestial_bodies() -> &'static [CelestialBody] {
+    &[
+        CelestialBody::Sun,
+        CelestialBody::Moon,
+        CelestialBody::Mercury,
+        CelestialBody::Venus,
+        CelestialBody::Mars,
+        CelestialBody::Jupiter,
+        CelestialBody::Saturn,
+        CelestialBody::Rahu,
+        CelestialBody::Ketu,
+    ]
+}
+
+fn changelog_url_from_env() -> String {
+    std::env::var("GITHUB_REPO_URL")
+        .map(|base| format!("{}/blob/main/CHANGELOG.md", base.trim_end_matches('/')))
+        .unwrap_or_else(|_| DEFAULT_CHANGELOG_URL.to_owned())
+}
+
+fn ayanamsa_id_from_model(model: AyanamsaModel) -> String {
+    serde_json::to_value(model)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "lahiri".to_owned())
+}
+
+fn kernel_catalog(kernel_hash: &str) -> (&'static str, &'static str) {
+    if kernel_hash.is_empty() {
+        ("demo", "In-memory analytic ephemeris")
+    } else {
+        ("de440", "JPL DE440")
+    }
+}
+
+pub fn build_provenance_response(state: &ApiState) -> ProvenanceResponse {
+    let (kernel_id, kernel_source) = kernel_catalog(state.kernel_hash());
+    let ayanamsa_id = ayanamsa_id_from_model(state.config.ayanamsa);
+    ProvenanceResponse {
+        engine_semantic_version: ENGINE_SEMANTIC_VERSION.to_owned(),
+        version: state.engine_version().to_owned(),
+        engine_mode: state.config.mode,
+        ayanamsa_used: state.config.ayanamsa,
+        house_system: state.config.house_system,
+        gravitational_deflection: state.config.gravitational_deflection,
+        kernel_hash: state.kernel_hash().to_owned(),
+        kernel_load_seconds: state.kernel_load_seconds(),
+        kernel_id: kernel_id.to_owned(),
+        kernel_source: kernel_source.to_owned(),
+        ayanamsa_id: ayanamsa_id.clone(),
+        ayanamsa_algorithm: LAHIRI_ALGO_ID.to_owned(),
+        ayanamsa_version: LAHIRI_ALGO_ID.to_owned(),
+        git_commit: BUILD_GIT_COMMIT.to_owned(),
+        build_date: BUILD_DATE_RFC3339.to_owned(),
+        tolerance_arcsec: PROVENANCE_TOLERANCE_ARCSEC,
+        validation_baseline: VALIDATION_BASELINE.to_owned(),
+        changelog_url: changelog_url_from_env(),
+        node_policy_id: NODE_POLICY_ID.to_owned(),
+        supported_bodies: supported_celestial_bodies().to_vec(),
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -337,9 +438,11 @@ where
 
 fn build_app_router(state: ApiState, auth: ApiAuthConfig) -> Router {
     let rate_limiter = RateLimiter::from_env();
+    let observability_state = state.clone();
     Router::new()
         .route("/health", get(health))
         .route("/provenance", get(provenance))
+        .route("/metrics", get(metrics_endpoint))
         .route("/positions", post(positions))
         .route("/positions/sidereal", post(sidereal_positions))
         .route("/chart/sidereal", post(sidereal_chart))
@@ -358,7 +461,7 @@ fn build_app_router(state: ApiState, auth: ApiAuthConfig) -> Router {
             let auth = auth.clone();
             async move { auth_middleware(request, next, auth).await }
         }))
-        .layer(middleware::from_fn(observability_middleware))
+        .layer(middleware::from_fn_with_state(observability_state, observability_middleware))
 }
 
 #[derive(Clone, Debug)]
@@ -530,6 +633,7 @@ fn is_public_route(method: &Method, path: &str) -> bool {
         (method, path),
         (&Method::GET, "/health")
             | (&Method::GET, "/provenance")
+            | (&Method::GET, "/metrics")
             | (&Method::GET, "/openapi.json")
             | (&Method::GET, "/docs")
     )
@@ -557,7 +661,12 @@ fn unauthorized_response(error: &'static str) -> Response {
     (StatusCode::UNAUTHORIZED, Json(ErrorPayload { error: error.to_owned() })).into_response()
 }
 
-async fn observability_middleware(mut request: Request, next: Next) -> Response {
+async fn observability_middleware(
+    State(state): State<ApiState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    init_observability(&state);
     let started_at = Instant::now();
     let method = request.method().clone();
     let path = request.uri().path().to_owned();
@@ -572,17 +681,27 @@ async fn observability_middleware(mut request: Request, next: Next) -> Response 
         response.headers_mut().insert(REQUEST_ID_HEADER, header_value);
     }
 
-    emit_request_log(RequestLogEntry {
+    let status = response.status().as_u16();
+    let latency_ms = started_at.elapsed().as_millis();
+    metrics::record_request(&path, status, latency_ms);
+    let log_entry = RequestLogEntry {
         method: &method,
         path: &path,
         query: query.as_deref(),
-        status: response.status().as_u16(),
-        latency_ms: started_at.elapsed().as_millis(),
+        status,
+        latency_ms,
         request_id: &request_id,
         body_hash: body_hash.as_deref(),
         api_key_prefix: &api_key_prefix,
         headers: &headers,
-    });
+    };
+    let engine_version = state.engine_version();
+    let kernel_hash = state.kernel_hash();
+    emit_request_log(&log_entry, engine_version, kernel_hash);
+    if should_emit_slo_breach(log_entry.path, status, latency_ms) {
+        let target_ms = slo_target_ms(log_entry.path).expect("checked by should_emit_slo_breach");
+        emit_slo_breach_log(&log_entry, target_ms, engine_version, kernel_hash);
+    }
 
     response
 }
@@ -599,7 +718,11 @@ struct RequestLogEntry<'a> {
     headers: &'a HeaderMap,
 }
 
-fn emit_request_log(entry: RequestLogEntry<'_>) {
+fn request_log_payload(
+    entry: &RequestLogEntry<'_>,
+    engine_version: &str,
+    kernel_hash: &str,
+) -> Value {
     let mut payload = json!({
         "severity": request_log_severity(entry.status),
         "message": "api_usage",
@@ -609,6 +732,8 @@ fn emit_request_log(entry: RequestLogEntry<'_>) {
         "path": entry.path,
         "status": entry.status,
         "latency_ms": entry.latency_ms,
+        "engine_version": engine_version,
+        "kernel_hash": kernel_hash,
     });
 
     if let Some(query) = entry.query {
@@ -641,6 +766,55 @@ fn emit_request_log(entry: RequestLogEntry<'_>) {
         }
     }
 
+    payload
+}
+
+fn emit_request_log(entry: &RequestLogEntry<'_>, engine_version: &str, kernel_hash: &str) {
+    let payload = request_log_payload(entry, engine_version, kernel_hash);
+    eprintln!("{payload}");
+}
+
+const CHART_SIDEREAL_SLO_MS: u128 = 200;
+const DASHA_SLO_MS: u128 = 300;
+
+fn slo_target_ms(path: &str) -> Option<u128> {
+    match path {
+        "/chart/sidereal" => Some(CHART_SIDEREAL_SLO_MS),
+        "/dasha" => Some(DASHA_SLO_MS),
+        _ => None,
+    }
+}
+
+fn should_emit_slo_breach(path: &str, status: u16, latency_ms: u128) -> bool {
+    (200..300).contains(&status) && slo_target_ms(path).is_some_and(|target| latency_ms > target)
+}
+
+fn slo_breach_payload(
+    entry: &RequestLogEntry<'_>,
+    target_ms: u128,
+    engine_version: &str,
+    kernel_hash: &str,
+) -> Value {
+    json!({
+        "severity": "WARNING",
+        "message": "slo_breach",
+        "slo_breach": true,
+        "path": entry.path,
+        "target_ms": target_ms,
+        "actual_ms": entry.latency_ms,
+        "request_id": entry.request_id,
+        "engine_version": engine_version,
+        "kernel_hash": kernel_hash,
+    })
+}
+
+fn emit_slo_breach_log(
+    entry: &RequestLogEntry<'_>,
+    target_ms: u128,
+    engine_version: &str,
+    kernel_hash: &str,
+) {
+    let payload = slo_breach_payload(entry, target_ms, engine_version, kernel_hash);
     eprintln!("{payload}");
 }
 
@@ -739,21 +913,64 @@ fn forwarded_for_ip(headers: &HeaderMap) -> Option<String> {
         .map(|value| value.split(',').next().map(str::trim).unwrap_or("").to_owned())
 }
 
+fn metrics_token_from_env() -> Option<String> {
+    std::env::var(METRICS_TOKEN_ENV_VAR)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+async fn metrics_endpoint(State(state): State<ApiState>, headers: HeaderMap) -> Response {
+    let Some(expected_token) = metrics_token_from_env() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorPayload { error: "metrics_disabled".to_owned() }),
+        )
+            .into_response();
+    };
+
+    init_observability(&state);
+
+    let Some(token) = bearer_token(&headers) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorPayload { error: "missing_metrics_token".to_owned() }),
+        )
+            .into_response();
+    };
+
+    if token != expected_token {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorPayload { error: "invalid_metrics_token".to_owned() }),
+        )
+            .into_response();
+    }
+
+    let Some(body) = metrics::render() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorPayload { error: "metrics_disabled".to_owned() }),
+        )
+            .into_response();
+    };
+
+    (
+        StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")],
+        body,
+    )
+        .into_response()
+}
+
 async fn health(State(state): State<ApiState>) -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok", version: state.version })
 }
 
-async fn provenance(State(state): State<ApiState>) -> Json<ProvenanceResponse> {
-    Json(ProvenanceResponse {
-        engine_semantic_version: ENGINE_SEMANTIC_VERSION.to_owned(),
-        version: state.version.clone(),
-        engine_mode: state.config.mode,
-        ayanamsa_used: state.config.ayanamsa,
-        house_system: state.config.house_system,
-        gravitational_deflection: state.config.gravitational_deflection,
-        kernel_hash: state.kernel_hash.clone(),
-        kernel_load_seconds: state.kernel_load_seconds,
-    })
+async fn provenance(State(state): State<ApiState>) -> Response {
+    let cache_control = HeaderValue::from_static("public, max-age=3600");
+    (StatusCode::OK, [(CACHE_CONTROL, cache_control)], Json(build_provenance_response(&state)))
+        .into_response()
 }
 
 async fn openapi_json() -> Json<Value> {
@@ -820,11 +1037,8 @@ async fn dasha(
     let include_timeline = request.include_timeline.unwrap_or(false);
 
     let payload = if include_timeline {
-        let (current, timeline) = vimshottari_timeline(
-            request.moon_sidereal_longitude_deg,
-            birth_time,
-            as_of,
-        );
+        let (current, timeline) =
+            vimshottari_timeline(request.moon_sidereal_longitude_deg, birth_time, as_of);
         DashaPayload {
             dasha: current.clone(),
             schema_version: DASHA_SCHEMA_VERSION.to_string(),
@@ -1021,7 +1235,7 @@ fn compute_sidereal_positions(
 fn build_sidereal_position(
     tropical: PositionResult,
     jd_tdb: f64,
-    motion: LongitudeMotion,
+    motion: astro_core::LongitudeMotion,
     projection: ChartProjection,
 ) -> SiderealPositionResult {
     let sidereal_longitude = sidereal_longitude_deg(tropical.position.longitude_deg, jd_tdb);
@@ -1039,7 +1253,7 @@ fn build_sidereal_position(
         tropical_longitude_deg: include_tropical.then_some(tropical.position.longitude_deg),
         tropical_latitude_deg: include_tropical.then_some(tropical.position.latitude_deg),
         sidereal_longitude_deg: sidereal_longitude,
-        longitude_speed_deg_per_day: motion.speed_deg_per_day,
+        longitude_speed_deg_per_day: motion.longitude_speed_deg_per_day,
         retrograde: motion.retrograde,
         distance_au: tropical.position.distance_au,
         moon_division,
@@ -1233,41 +1447,9 @@ fn body_longitude_motion(
     body: CelestialBody,
     jd_utc: f64,
     config: &EngineConfig,
-) -> Result<LongitudeMotion, SiderealRequestError> {
-    let previous = state
-        .backend
-        .position(
-            body,
-            jd_utc - RETROGRADE_DELTA_DAYS,
-            CoordinateFrame::EclipticGeocentric,
-            None,
-            config,
-        )
-        .map_err(SiderealRequestError::Backend)?;
-    let next = state
-        .backend
-        .position(
-            body,
-            jd_utc + RETROGRADE_DELTA_DAYS,
-            CoordinateFrame::EclipticGeocentric,
-            None,
-            config,
-        )
-        .map_err(SiderealRequestError::Backend)?;
-    let delta =
-        signed_longitude_delta_deg(previous.position.longitude_deg, next.position.longitude_deg);
-    let speed_deg_per_day = delta / (RETROGRADE_DELTA_DAYS * 2.0);
-    Ok(LongitudeMotion { speed_deg_per_day, retrograde: speed_deg_per_day < 0.0 })
-}
-
-fn signed_longitude_delta_deg(start_deg: f64, end_deg: f64) -> f64 {
-    (end_deg - start_deg + 540.0).rem_euclid(360.0) - 180.0
-}
-
-#[derive(Debug, Clone, Copy)]
-struct LongitudeMotion {
-    speed_deg_per_day: f64,
-    retrograde: bool,
+) -> Result<astro_core::LongitudeMotion, SiderealRequestError> {
+    astro_core::longitude_motion(state.backend.as_ref(), body, jd_utc, config)
+        .map_err(SiderealRequestError::Backend)
 }
 
 fn rashi_lord(rashi: Rashi) -> CelestialBody {
@@ -1428,7 +1610,19 @@ pub fn openapi_spec() -> Value {
                         "house_system",
                         "gravitational_deflection",
                         "kernel_hash",
-                        "kernel_load_seconds"
+                        "kernel_load_seconds",
+                        "kernel_id",
+                        "kernel_source",
+                        "ayanamsa_id",
+                        "ayanamsa_algorithm",
+                        "ayanamsa_version",
+                        "git_commit",
+                        "build_date",
+                        "tolerance_arcsec",
+                        "validation_baseline",
+                        "changelog_url",
+                        "node_policy_id",
+                        "supported_bodies"
                     ],
                     "properties": {
                         "engine_semantic_version": { "type": "string" },
@@ -1438,7 +1632,22 @@ pub fn openapi_spec() -> Value {
                         "house_system": { "type": "string" },
                         "gravitational_deflection": { "type": "boolean" },
                         "kernel_hash": { "type": "string" },
-                        "kernel_load_seconds": { "type": "number" }
+                        "kernel_load_seconds": { "type": "number" },
+                        "kernel_id": { "type": "string", "example": "de440" },
+                        "kernel_source": { "type": "string", "example": "JPL DE440" },
+                        "ayanamsa_id": { "type": "string", "example": "lahiri" },
+                        "ayanamsa_algorithm": { "type": "string", "example": "lahiri_swe_zero_epoch_iau1976_v1" },
+                        "ayanamsa_version": { "type": "string", "example": "lahiri_swe_zero_epoch_iau1976_v1" },
+                        "git_commit": { "type": "string" },
+                        "build_date": { "type": "string", "format": "date-time" },
+                        "tolerance_arcsec": { "type": "number", "example": 0.00036 },
+                        "validation_baseline": { "type": "string", "example": "JPL Horizons" },
+                        "changelog_url": { "type": "string", "format": "uri" },
+                        "node_policy_id": { "type": "string" },
+                        "supported_bodies": {
+                            "type": "array",
+                            "items": { "$ref": "#/components/schemas/CelestialBody" }
+                        }
                     }
                 },
                 "SiderealPositionsRequest": {
@@ -2013,6 +2222,11 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(())).lock().expect("env lock poisoned")
     }
 
+    fn metrics_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().expect("metrics test lock poisoned")
+    }
+
     fn test_app() -> Router {
         app_router_with_api_keys(demo_state(), [TEST_API_KEY])
     }
@@ -2077,6 +2291,211 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn request_id_header_canonical_casing_is_preserved() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/health")
+                    .header("X-Request-Id", "canonical-case-id-789")
+                    .body(Body::empty())
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(
+            response.headers().get(REQUEST_ID_HEADER).and_then(|value| value.to_str().ok()),
+            Some("canonical-case-id-789")
+        );
+    }
+
+    #[test]
+    fn request_log_payload_includes_engine_version_and_kernel_hash() {
+        let headers = HeaderMap::new();
+        let entry = RequestLogEntry {
+            method: &Method::POST,
+            path: "/chart/sidereal",
+            query: None,
+            status: 200,
+            latency_ms: 42,
+            request_id: "req-1",
+            body_hash: Some("sha256:abc"),
+            api_key_prefix: "testkey…",
+            headers: &headers,
+        };
+        let payload = request_log_payload(&entry, "0.1.0", "kernel-digest");
+        assert_eq!(payload["message"].as_str(), Some("api_usage"));
+        assert_eq!(payload["request_id"].as_str(), Some("req-1"));
+        assert_eq!(payload["path"].as_str(), Some("/chart/sidereal"));
+        assert_eq!(payload["status"].as_u64(), Some(200));
+        assert_eq!(payload["latency_ms"].as_u64(), Some(42));
+        assert_eq!(payload["engine_version"].as_str(), Some("0.1.0"));
+        assert_eq!(payload["kernel_hash"].as_str(), Some("kernel-digest"));
+        assert_eq!(payload["api_key_prefix"].as_str(), Some("testkey…"));
+        assert_eq!(payload["request_body_hash"].as_str(), Some("sha256:abc"));
+    }
+
+    fn sample_log_entry<'a>(
+        path: &'a str,
+        status: u16,
+        latency_ms: u128,
+        headers: &'a HeaderMap,
+    ) -> RequestLogEntry<'a> {
+        RequestLogEntry {
+            method: &Method::POST,
+            path,
+            query: None,
+            status,
+            latency_ms,
+            request_id: "req-slo-test",
+            body_hash: None,
+            api_key_prefix: "testkey…",
+            headers,
+        }
+    }
+
+    #[test]
+    fn slo_breach_payload_emitted_when_latency_exceeds_chart_sidereal_target() {
+        let headers = HeaderMap::new();
+        let entry = sample_log_entry("/chart/sidereal", 200, 201, &headers);
+        assert!(should_emit_slo_breach(entry.path, entry.status, entry.latency_ms));
+        let payload = slo_breach_payload(&entry, CHART_SIDEREAL_SLO_MS, "0.17.2", "kernel-digest");
+        assert_eq!(payload["severity"].as_str(), Some("WARNING"));
+        assert_eq!(payload["message"].as_str(), Some("slo_breach"));
+        assert_eq!(payload["slo_breach"].as_bool(), Some(true));
+        assert_eq!(payload["path"].as_str(), Some("/chart/sidereal"));
+        assert_eq!(payload["target_ms"].as_u64(), Some(200));
+        assert_eq!(payload["actual_ms"].as_u64(), Some(201));
+        assert_eq!(payload["request_id"].as_str(), Some("req-slo-test"));
+        assert_eq!(payload["engine_version"].as_str(), Some("0.17.2"));
+        assert_eq!(payload["kernel_hash"].as_str(), Some("kernel-digest"));
+    }
+
+    #[test]
+    fn slo_breach_not_emitted_at_exact_chart_sidereal_target() {
+        let headers = HeaderMap::new();
+        let entry = sample_log_entry("/chart/sidereal", 200, 200, &headers);
+        assert!(!should_emit_slo_breach(entry.path, entry.status, entry.latency_ms));
+    }
+
+    #[test]
+    fn slo_breach_not_emitted_for_non_success_status() {
+        assert!(!should_emit_slo_breach("/chart/sidereal", 500, 500));
+        assert!(!should_emit_slo_breach("/chart/sidereal", 404, 500));
+    }
+
+    #[test]
+    fn slo_breach_not_emitted_for_untracked_paths() {
+        assert!(!should_emit_slo_breach("/health", 200, 10_000));
+    }
+
+    #[test]
+    fn slo_breach_payload_emitted_when_latency_exceeds_dasha_target() {
+        let headers = HeaderMap::new();
+        let entry = sample_log_entry("/dasha", 200, 301, &headers);
+        assert!(should_emit_slo_breach(entry.path, entry.status, entry.latency_ms));
+        let payload = slo_breach_payload(&entry, DASHA_SLO_MS, "0.17.2", "kernel-digest");
+        assert_eq!(payload["path"].as_str(), Some("/dasha"));
+        assert_eq!(payload["target_ms"].as_u64(), Some(300));
+        assert_eq!(payload["actual_ms"].as_u64(), Some(301));
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn metrics_returns_503_when_token_unset() {
+        let _serial = metrics_test_lock();
+        std::env::remove_var(METRICS_TOKEN_ENV_VAR);
+
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn metrics_returns_401_without_bearer_token() {
+        let _serial = metrics_test_lock();
+        std::env::set_var(METRICS_TOKEN_ENV_VAR, "test-metrics-secret");
+
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        std::env::remove_var(METRICS_TOKEN_ENV_VAR);
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn metrics_returns_403_with_invalid_bearer_token() {
+        let _serial = metrics_test_lock();
+        std::env::set_var(METRICS_TOKEN_ENV_VAR, "test-metrics-secret");
+
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/metrics")
+                    .header(AUTHORIZATION_HEADER, "Bearer wrong-token")
+                    .body(Body::empty())
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        std::env::remove_var(METRICS_TOKEN_ENV_VAR);
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn metrics_returns_prometheus_body_with_valid_bearer_token() {
+        let _serial = metrics_test_lock();
+        std::env::set_var(METRICS_TOKEN_ENV_VAR, "test-metrics-secret");
+
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/metrics")
+                    .header(AUTHORIZATION_HEADER, "Bearer test-metrics-secret")
+                    .body(Body::empty())
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
+        let text = String::from_utf8(body.to_vec()).expect("metrics body must be utf-8");
+        assert!(text.contains("astro_requests_total"));
+        assert!(text.contains("astro_kernel_load_seconds"));
+        std::env::remove_var(METRICS_TOKEN_ENV_VAR);
+    }
+
     #[test]
     fn body_hash_is_stable_sha256() {
         assert_eq!(
@@ -2131,8 +2550,10 @@ mod tests {
 
     #[tokio::test]
     async fn rate_limit_returns_429_with_retry_after() {
-        let _guard = env_lock();
-        std::env::set_var(RATE_LIMIT_RPM_ENV_VAR, "2");
+        {
+            let _guard = env_lock();
+            std::env::set_var(RATE_LIMIT_RPM_ENV_VAR, "2");
+        }
 
         let app = test_app();
 
@@ -2165,7 +2586,10 @@ mod tests {
         let json: Value = serde_json::from_slice(&body).expect("body must be valid json");
         assert_eq!(json, serde_json::json!({ "error": "rate_limit_exceeded" }));
 
-        std::env::remove_var(RATE_LIMIT_RPM_ENV_VAR);
+        {
+            let _guard = env_lock();
+            std::env::remove_var(RATE_LIMIT_RPM_ENV_VAR);
+        }
     }
 
     #[test]
@@ -2554,10 +2978,7 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
         let html = String::from_utf8(body.to_vec()).expect("docs body must be utf-8");
         assert!(html.contains("spec-url=\"/openapi.json\""));
-        assert!(
-            html.contains(REDOC_STANDALONE_JS),
-            "expected pinned Redoc script URL in HTML",
-        );
+        assert!(html.contains(REDOC_STANDALONE_JS), "expected pinned Redoc script URL in HTML",);
     }
 
     #[tokio::test]
@@ -2575,11 +2996,28 @@ mod tests {
             .expect("response must succeed");
 
         assert_eq!(response.status(), StatusCode::OK);
+        let cache_control =
+            response.headers().get(CACHE_CONTROL).and_then(|value| value.to_str().ok());
+        assert_eq!(cache_control, Some("public, max-age=3600"));
         let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
         let json: Value = serde_json::from_slice(&body).expect("body must be valid json");
+        assert_eq!(json["engine_semantic_version"], ENGINE_SEMANTIC_VERSION);
         assert!(json["version"].is_string());
         assert!(json["kernel_hash"].is_string());
         assert!(json["kernel_load_seconds"].is_number());
+        assert_eq!(json["kernel_id"], "demo");
+        assert_eq!(json["kernel_source"], "In-memory analytic ephemeris");
+        assert_eq!(json["ayanamsa_id"], "lahiri");
+        assert_eq!(json["ayanamsa_algorithm"], LAHIRI_ALGO_ID);
+        assert_eq!(json["ayanamsa_version"], LAHIRI_ALGO_ID);
+        assert!(json["git_commit"].is_string());
+        assert!(json["build_date"].is_string());
+        assert_eq!(json["tolerance_arcsec"], PROVENANCE_TOLERANCE_ARCSEC);
+        assert_eq!(json["validation_baseline"], VALIDATION_BASELINE);
+        assert_eq!(json["changelog_url"], DEFAULT_CHANGELOG_URL);
+        assert_eq!(json["node_policy_id"], NODE_POLICY_ID);
+        let bodies = json["supported_bodies"].as_array().expect("supported_bodies array");
+        assert_eq!(bodies.len(), supported_celestial_bodies().len());
     }
 
     #[tokio::test]

--- a/crates/astro-api/src/lib.rs
+++ b/crates/astro-api/src/lib.rs
@@ -15,8 +15,9 @@ use astro_core::{
 use astro_vedic::{
     drekkana_sign, lagna_position_from_sidereal_longitude, moon_sidereal_division_from_tropical,
     navamsa_sign, sidereal_division, sidereal_longitude_deg, vimshottari_dasha,
-    vimshottari_dasha_at, whole_sign_houses_from_sidereal_ascendant, LagnaPosition, Nakshatra,
-    Rashi, SiderealDivision, VimshottariDasha, WholeSignHouse, LAHIRI_ALGO_ID,
+    vimshottari_dasha_at, vimshottari_timeline, whole_sign_houses_from_sidereal_ascendant,
+    LagnaPosition, Nakshatra, Rashi, SiderealDivision, VimshottariDasha, VimshottariTimeline,
+    WholeSignHouse, LAHIRI_ALGO_ID,
 };
 use axum::{
     body::{to_bytes, Body},
@@ -36,6 +37,7 @@ use uuid::Uuid;
 pub const ENGINE_SEMANTIC_VERSION: &str = "0.17.0";
 pub const NODE_POLICY_ID: &str = "true_node_mean_ecliptic_of_date";
 pub const CHART_SIDEREAL_SCHEMA_VERSION: &str = "chart_sidereal_v1";
+pub const DASHA_SCHEMA_VERSION: &str = "dasha_v2";
 const RETROGRADE_DELTA_DAYS: f64 = 0.5;
 const REQUEST_ID_HEADER: &str = "x-request-id";
 const CORRELATION_ID_HEADER: &str = "x-correlation-id";
@@ -57,6 +59,9 @@ pub struct ApiState {
     backend: Arc<dyn EphemerisBackend>,
     config: EngineConfig,
     version: String,
+    /// Stable digest for the loaded ephemeris kernel when known (hex sha256 over source + path).
+    kernel_hash: String,
+    kernel_load_seconds: f64,
 }
 
 impl ApiState {
@@ -65,7 +70,23 @@ impl ApiState {
         config: EngineConfig,
         version: impl Into<String>,
     ) -> Self {
-        Self { backend, config, version: version.into() }
+        Self {
+            backend,
+            config,
+            version: version.into(),
+            kernel_hash: String::new(),
+            kernel_load_seconds: 0.0,
+        }
+    }
+
+    pub fn with_kernel_provenance(
+        mut self,
+        kernel_hash: impl Into<String>,
+        kernel_load_seconds: f64,
+    ) -> Self {
+        self.kernel_hash = kernel_hash.into();
+        self.kernel_load_seconds = kernel_load_seconds;
+        self
     }
 }
 
@@ -73,6 +94,18 @@ impl ApiState {
 pub struct HealthResponse {
     pub status: &'static str,
     pub version: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct ProvenanceResponse {
+    pub engine_semantic_version: String,
+    pub version: String,
+    pub engine_mode: EngineMode,
+    pub ayanamsa_used: AyanamsaModel,
+    pub house_system: HouseSystem,
+    pub gravitational_deflection: bool,
+    pub kernel_hash: String,
+    pub kernel_load_seconds: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -255,11 +288,32 @@ pub struct FastestBodySummary {
 pub struct DashaRequest {
     pub moon_sidereal_longitude_deg: f64,
     pub birth_time_utc_rfc3339: String,
+    /// Optional RFC-3339 instant for the "current period" snapshot.
+    /// Defaults to UTC now when omitted (preserves dasha_v1 behaviour).
+    #[serde(default)]
+    pub as_of_utc_rfc3339: Option<String>,
+    /// When true, include the full Maha + Antar timeline in the response.
+    /// Defaults to false to preserve dasha_v1 payload shape.
+    #[serde(default)]
+    pub include_timeline: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DashaPayload {
+    /// Original dasha_v1 field — current Maha+Antar+Pratyantar snapshot.
+    /// Retained for backward compatibility; identical to `current`.
     pub dasha: VimshottariDasha,
+    /// Schema marker — "dasha_v1" when timeline omitted, "dasha_v2" when present.
+    #[serde(default)]
+    pub schema_version: String,
+    /// Current Maha+Antar+Pratyantar snapshot. Same content as `dasha`; named
+    /// for clarity in dasha_v2 clients that prefer not to overload `dasha`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current: Option<VimshottariDasha>,
+    /// Full Vimshottari timeline (9 Mahas, 81 Antars, 9 Pratyantars within the
+    /// current Antar). Present only when `include_timeline: true` in the request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeline: Option<VimshottariTimeline>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -285,6 +339,7 @@ fn build_app_router(state: ApiState, auth: ApiAuthConfig) -> Router {
     let rate_limiter = RateLimiter::from_env();
     Router::new()
         .route("/health", get(health))
+        .route("/provenance", get(provenance))
         .route("/positions", post(positions))
         .route("/positions/sidereal", post(sidereal_positions))
         .route("/chart/sidereal", post(sidereal_chart))
@@ -474,6 +529,7 @@ fn is_public_route(method: &Method, path: &str) -> bool {
     matches!(
         (method, path),
         (&Method::GET, "/health")
+            | (&Method::GET, "/provenance")
             | (&Method::GET, "/openapi.json")
             | (&Method::GET, "/docs")
     )
@@ -687,6 +743,19 @@ async fn health(State(state): State<ApiState>) -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok", version: state.version })
 }
 
+async fn provenance(State(state): State<ApiState>) -> Json<ProvenanceResponse> {
+    Json(ProvenanceResponse {
+        engine_semantic_version: ENGINE_SEMANTIC_VERSION.to_owned(),
+        version: state.version.clone(),
+        engine_mode: state.config.mode,
+        ayanamsa_used: state.config.ayanamsa,
+        house_system: state.config.house_system,
+        gravitational_deflection: state.config.gravitational_deflection,
+        kernel_hash: state.kernel_hash.clone(),
+        kernel_load_seconds: state.kernel_load_seconds,
+    })
+}
+
 async fn openapi_json() -> Json<Value> {
     Json(openapi_spec())
 }
@@ -739,12 +808,46 @@ async fn dasha(
         .map_err(|err| bad_request(err.to_string()))?
         .with_timezone(&Utc);
 
-    Ok(Json(ComputationResult {
-        data: DashaPayload {
-            dasha: vimshottari_dasha(request.moon_sidereal_longitude_deg, birth_time),
-        },
-        metadata: metadata(&state),
-    }))
+    // as_of defaults to "now" when the caller does not supply it, mirroring
+    // the existing dasha_v1 contract (vimshottari_dasha == _at(birth, birth)).
+    let as_of = match request.as_of_utc_rfc3339.as_deref() {
+        Some(value) => chrono::DateTime::parse_from_rfc3339(value)
+            .map_err(|err| bad_request(err.to_string()))?
+            .with_timezone(&Utc),
+        None => Utc::now(),
+    };
+
+    let include_timeline = request.include_timeline.unwrap_or(false);
+
+    let payload = if include_timeline {
+        let (current, timeline) = vimshottari_timeline(
+            request.moon_sidereal_longitude_deg,
+            birth_time,
+            as_of,
+        );
+        DashaPayload {
+            dasha: current.clone(),
+            schema_version: DASHA_SCHEMA_VERSION.to_string(),
+            current: Some(current),
+            timeline: Some(timeline),
+        }
+    } else {
+        // dasha_v1 behaviour preserved: if no as_of was passed, evaluate at
+        // birth (matches vimshottari_dasha); otherwise use the as_of snapshot.
+        let snapshot = if request.as_of_utc_rfc3339.is_some() {
+            vimshottari_dasha_at(request.moon_sidereal_longitude_deg, birth_time, as_of)
+        } else {
+            vimshottari_dasha(request.moon_sidereal_longitude_deg, birth_time)
+        };
+        DashaPayload {
+            dasha: snapshot,
+            schema_version: "dasha_v1".to_string(),
+            current: None,
+            timeline: None,
+        }
+    };
+
+    Ok(Json(ComputationResult { data: payload, metadata: metadata(&state) }))
 }
 
 async fn sidereal_positions(
@@ -1187,6 +1290,21 @@ pub fn openapi_spec() -> Value {
             "version": ENGINE_SEMANTIC_VERSION
         },
         "paths": {
+            "/provenance": {
+                "get": {
+                    "summary": "Return engine runtime provenance metadata",
+                    "responses": {
+                        "200": {
+                            "description": "Provenance payload",
+                            "content": {
+                                "application/json": {
+                                    "schema": { "$ref": "#/components/schemas/ProvenanceResponse" }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "/positions": {
                 "post": {
                     "summary": "Compute tropical positions",
@@ -1298,6 +1416,29 @@ pub fn openapi_spec() -> Value {
                             "type": "boolean",
                             "description": "When true, omits position distance and computation metadata for lightweight clients."
                         }
+                    }
+                },
+                "ProvenanceResponse": {
+                    "type": "object",
+                    "required": [
+                        "engine_semantic_version",
+                        "version",
+                        "engine_mode",
+                        "ayanamsa_used",
+                        "house_system",
+                        "gravitational_deflection",
+                        "kernel_hash",
+                        "kernel_load_seconds"
+                    ],
+                    "properties": {
+                        "engine_semantic_version": { "type": "string" },
+                        "version": { "type": "string" },
+                        "engine_mode": { "type": "string" },
+                        "ayanamsa_used": { "type": "string" },
+                        "house_system": { "type": "string" },
+                        "gravitational_deflection": { "type": "boolean" },
+                        "kernel_hash": { "type": "string" },
+                        "kernel_load_seconds": { "type": "number" }
                     }
                 },
                 "SiderealPositionsRequest": {
@@ -1690,6 +1831,28 @@ pub fn openapi_spec() -> Value {
                         "antar": { "$ref": "#/components/schemas/DashaPeriod" },
                         "pratyantar": { "$ref": "#/components/schemas/DashaPeriod" }
                     }
+                },
+                "VimshottariTimeline": {
+                    "type": "object",
+                    "description": "Full Vimshottari timeline (dasha_v2). Returned when include_timeline=true on POST /dasha.",
+                    "properties": {
+                        "mahadashas": {
+                            "type": "array",
+                            "items": { "$ref": "#/components/schemas/DashaPeriod" },
+                            "description": "9 Mahadashas spanning the 120-yr cycle from birth_time."
+                        },
+                        "antardashas": {
+                            "type": "array",
+                            "items": { "$ref": "#/components/schemas/DashaPeriod" },
+                            "description": "81 Antardashas (9 per Maha) in chronological order."
+                        },
+                        "current_antar_pratyantars": {
+                            "type": "array",
+                            "items": { "$ref": "#/components/schemas/DashaPeriod" },
+                            "description": "9 Pratyantars within the currently-active Antar."
+                        }
+                    },
+                    "required": ["mahadashas", "antardashas", "current_antar_pratyantars"]
                 },
                 "DashaPeriod": {
                     "type": "object",
@@ -2322,6 +2485,7 @@ mod tests {
         assert!(json["paths"]["/chart/sidereal"]["post"].is_object());
         assert!(json["paths"]["/positions"]["post"].is_object());
         assert!(json["paths"]["/positions/sidereal"]["post"].is_object());
+        assert!(json["paths"]["/provenance"]["get"].is_object());
         assert!(json["components"]["schemas"]["SiderealChartPayload"]["properties"]["dasha"]
             .is_object());
         assert!(json["components"]["schemas"]["SiderealChartPayload"]["properties"]["summary"]
@@ -2394,6 +2558,28 @@ mod tests {
             html.contains(REDOC_STANDALONE_JS),
             "expected pinned Redoc script URL in HTML",
         );
+    }
+
+    #[tokio::test]
+    async fn provenance_route_is_public_and_returns_runtime_metadata() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/provenance")
+                    .body(Body::empty())
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
+        let json: Value = serde_json::from_slice(&body).expect("body must be valid json");
+        assert!(json["version"].is_string());
+        assert!(json["kernel_hash"].is_string());
+        assert!(json["kernel_load_seconds"].is_number());
     }
 
     #[tokio::test]
@@ -2498,5 +2684,69 @@ mod tests {
             .expect("response must succeed");
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn dasha_endpoint_omits_timeline_by_default() {
+        // Backward compatibility: a dasha_v1 caller (no include_timeline) gets
+        // the original payload shape; `timeline` is absent on the wire.
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/dasha")
+                    .header(API_KEY_HEADER, TEST_API_KEY)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"moon_sidereal_longitude_deg":15.0,"birth_time_utc_rfc3339":"2024-01-01T00:00:00Z"}"#,
+                    ))
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
+        let json: Value = serde_json::from_slice(&body).expect("body must be valid json");
+        assert!(json["data"]["dasha"].is_object());
+        assert_eq!(json["data"]["schema_version"], "dasha_v1");
+        assert!(json["data"].get("timeline").is_none() || json["data"]["timeline"].is_null());
+    }
+
+    #[tokio::test]
+    async fn dasha_endpoint_returns_timeline_when_requested() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/dasha")
+                    .header(API_KEY_HEADER, TEST_API_KEY)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{
+                            "moon_sidereal_longitude_deg": 99.586412769677720,
+                            "birth_time_utc_rfc3339": "2000-01-01T12:00:00Z",
+                            "as_of_utc_rfc3339": "2005-01-01T12:00:00Z",
+                            "include_timeline": true
+                        }"#,
+                    ))
+                    .expect("request must build"),
+            )
+            .await
+            .expect("response must succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
+        let json: Value = serde_json::from_slice(&body).expect("body must be valid json");
+        assert_eq!(json["data"]["schema_version"], "dasha_v2");
+        let timeline = &json["data"]["timeline"];
+        assert!(timeline.is_object());
+        assert_eq!(timeline["mahadashas"].as_array().unwrap().len(), 9);
+        assert_eq!(timeline["antardashas"].as_array().unwrap().len(), 81);
+        assert_eq!(timeline["current_antar_pratyantars"].as_array().unwrap().len(), 9);
+        // The "current" field must agree with the standalone "dasha" field.
+        assert_eq!(json["data"]["dasha"]["maha"]["lord"], json["data"]["current"]["maha"]["lord"]);
     }
 }

--- a/crates/astro-api/src/main.rs
+++ b/crates/astro-api/src/main.rs
@@ -7,6 +7,7 @@ use astro_core::{
     De440Backend,
 };
 use chrono::{TimeZone, Utc};
+use sha2::Digest;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackendMode {
@@ -97,11 +98,16 @@ async fn app_state_from_env() -> Result<(ApiState, BackendMode, Option<KernelRes
                     resolution.path.display()
                 ));
             }
+            let mut kernel_hasher = sha2::Sha256::new();
+            kernel_hasher.update(resolution.source.as_bytes());
+            kernel_hasher.update(resolution.path.display().to_string().as_bytes());
+            let kernel_hash = format!("{:x}", kernel_hasher.finalize());
             let state = ApiState::new(
                 std::sync::Arc::new(backend),
                 astro_core::EngineConfig::default(),
                 env!("CARGO_PKG_VERSION"),
-            );
+            )
+            .with_kernel_provenance(kernel_hash, resolution.elapsed.as_secs_f64());
             Ok((state, backend_mode, Some(resolution)))
         }
     }

--- a/crates/astro-api/src/main.rs
+++ b/crates/astro-api/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, net::SocketAddr};
 
-use astro_api::{app_router, demo_state, ApiState};
+use astro_api::{app_router, demo_state, init_observability, ApiState};
 use astro_core::{
     kernel_resolver::{resolve_kernel_from_env, KernelResolution},
     time::julian_day,
@@ -125,6 +125,7 @@ async fn main() {
         );
     }
     eprintln!("astro-api starting with ASTRO_BACKEND={}", backend_mode.as_str());
+    init_observability(&state);
     let app = app_router(state);
     let addr =
         bind_addr_from_env_vars(env::var("HOST").ok().as_deref(), env::var("PORT").ok().as_deref())
@@ -176,13 +177,15 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn app_state_uses_demo_without_kernel() {
-        let _guard = env_lock();
-        std::env::remove_var("ASTRO_BACKEND");
-        std::env::remove_var("ASTRO_EPHE_PATH");
-        std::env::remove_var("ASTRO_EPHE_GCS_URI");
-        std::env::remove_var("ENVIRONMENT");
-        std::env::remove_var("NODE_ENV");
-        std::env::remove_var("ALLOW_DEMO_BACKEND");
+        {
+            let _guard = env_lock();
+            std::env::remove_var("ASTRO_BACKEND");
+            std::env::remove_var("ASTRO_EPHE_PATH");
+            std::env::remove_var("ASTRO_EPHE_GCS_URI");
+            std::env::remove_var("ENVIRONMENT");
+            std::env::remove_var("NODE_ENV");
+            std::env::remove_var("ALLOW_DEMO_BACKEND");
+        }
         let (_, mode, kernel_resolution) =
             app_state_from_env().await.expect("demo backend must initialize without kernel");
         assert_eq!(mode, BackendMode::Demo);

--- a/crates/astro-api/src/metrics.rs
+++ b/crates/astro-api/src/metrics.rs
@@ -1,0 +1,33 @@
+use std::sync::OnceLock;
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+use crate::ApiState;
+
+static PROMETHEUS: OnceLock<PrometheusHandle> = OnceLock::new();
+
+pub fn init(state: &ApiState) {
+    PROMETHEUS.get_or_init(|| {
+        let handle = PrometheusBuilder::new()
+            .install_recorder()
+            .expect("failed to install Prometheus metrics recorder");
+        metrics::gauge!("astro_kernel_load_seconds").set(state.kernel_load_seconds());
+        handle
+    });
+}
+
+pub fn record_request(path: &str, status: u16, latency_ms: u128) {
+    let status_label = status.to_string();
+    metrics::counter!(
+        "astro_requests_total",
+        "path" => path.to_string(),
+        "status" => status_label
+    )
+    .increment(1);
+    metrics::histogram!("astro_request_latency_ms", "path" => path.to_string())
+        .record(latency_ms as f64);
+}
+
+pub fn render() -> Option<String> {
+    PROMETHEUS.get().map(PrometheusHandle::render)
+}

--- a/crates/astro-api/tests/positions_contract.rs
+++ b/crates/astro-api/tests/positions_contract.rs
@@ -1,4 +1,6 @@
-use astro_api::{app_router_with_api_keys, de440_state_from_env, demo_state, CHART_SIDEREAL_SCHEMA_VERSION};
+use astro_api::{
+    app_router_with_api_keys, de440_state_from_env, demo_state, CHART_SIDEREAL_SCHEMA_VERSION,
+};
 use axum::{
     body::{to_bytes, Body},
     http::{Method, Request, StatusCode},
@@ -770,11 +772,7 @@ async fn protected_post_routes_return_401_without_api_key() {
     let app = app_router_with_api_keys(demo_state(), [TEST_API_KEY]);
 
     for (method, uri, body) in [
-        (
-            Method::POST,
-            "/positions",
-            r#"{"julian_day":2451545.0,"bodies":["moon"]}"#,
-        ),
+        (Method::POST, "/positions", r#"{"julian_day":2451545.0,"bodies":["moon"]}"#),
         (
             Method::POST,
             "/positions/sidereal",
@@ -804,8 +802,13 @@ async fn protected_post_routes_return_401_without_api_key() {
             .await
             .expect("response must succeed");
 
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "expected 401 for {uri} without credentials");
-        let bytes = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "expected 401 for {uri} without credentials"
+        );
+        let bytes =
+            to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
         let json: Value = serde_json::from_slice(&bytes).expect("body must be json");
         assert_eq!(json["error"].as_str(), Some("missing_api_key"));
     }

--- a/crates/astro-api/tests/production_contract.rs
+++ b/crates/astro-api/tests/production_contract.rs
@@ -8,7 +8,10 @@ fn deployed_base_url() -> Option<String> {
 
 /// API key that is configured in the deployment's `VALID_API_KEYS`. Used for authenticated contract checks.
 fn deployed_api_key() -> Option<String> {
-    std::env::var("ASTRO_API_KEY").ok().map(|value| value.trim().to_owned()).filter(|value| !value.is_empty())
+    std::env::var("ASTRO_API_KEY")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
 }
 
 fn require_deployed_base_url() -> Option<String> {
@@ -20,9 +23,7 @@ fn require_deployed_base_url() -> Option<String> {
 }
 
 fn require_deployed_base_url_and_api_key() -> Option<(String, String)> {
-    let Some(base_url) = require_deployed_base_url() else {
-        return None;
-    };
+    let base_url = require_deployed_base_url()?;
     let Some(api_key) = deployed_api_key() else {
         eprintln!("skipping authenticated production contract test because ASTRO_API_KEY is unset");
         return None;
@@ -47,7 +48,12 @@ async fn post_json(client: &Client, url: &str, payload: Value) -> reqwest::Respo
         .expect("request must succeed")
 }
 
-async fn post_json_with_api_key(client: &Client, url: &str, payload: Value, api_key: &str) -> reqwest::Response {
+async fn post_json_with_api_key(
+    client: &Client,
+    url: &str,
+    payload: Value,
+    api_key: &str,
+) -> reqwest::Response {
     client
         .post(url)
         .header("content-type", "application/json")
@@ -221,12 +227,15 @@ async fn deployed_protected_routes_return_401_without_api_key() {
     };
 
     let client = http_client();
-    let sidereal = post_json(&client, &format!("{base_url}/positions/sidereal"), minimal_sidereal_payload()).await;
+    let sidereal =
+        post_json(&client, &format!("{base_url}/positions/sidereal"), minimal_sidereal_payload())
+            .await;
     assert_eq!(sidereal.status(), reqwest::StatusCode::UNAUTHORIZED);
     let body: Value = sidereal.json().await.expect("sidereal error body must be json");
     assert_eq!(body["error"].as_str(), Some("missing_api_key"));
 
-    let chart = post_json(&client, &format!("{base_url}/chart/sidereal"), minimal_chart_payload()).await;
+    let chart =
+        post_json(&client, &format!("{base_url}/chart/sidereal"), minimal_chart_payload()).await;
     assert_eq!(chart.status(), reqwest::StatusCode::UNAUTHORIZED);
     let body: Value = chart.json().await.expect("chart error body must be json");
     assert_eq!(body["error"].as_str(), Some("missing_api_key"));

--- a/crates/astro-api/tests/synthetic_chart_golden.rs
+++ b/crates/astro-api/tests/synthetic_chart_golden.rs
@@ -1,0 +1,71 @@
+use astro_api::{app_router_with_api_keys, de440_state_from_env};
+use axum::{
+    body::{to_bytes, Body},
+    http::{Method, Request, StatusCode},
+};
+use serde::Deserialize;
+use serde_json::Value;
+use tower::util::ServiceExt;
+
+#[path = "../../../tests/support/de440_kernel.rs"]
+mod de440_kernel;
+
+const TEST_API_KEY: &str = "test-api-key";
+
+#[derive(Debug, Deserialize)]
+struct SyntheticGoldenFixture {
+    request: Value,
+    expected_lagna_sidereal_longitude_deg: f64,
+    expected_lagna_rashi: String,
+    tolerance_deg: f64,
+}
+
+fn load_fixture() -> SyntheticGoldenFixture {
+    let raw = include_str!("../../../tests/golden/synthetic/delhi-1990-chart.json");
+    serde_json::from_str(raw).expect("synthetic golden fixture must parse")
+}
+
+fn authenticated_request(method: Method, uri: &str) -> axum::http::request::Builder {
+    Request::builder().method(method).uri(uri).header("x-api-key", TEST_API_KEY)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn delhi_1990_chart_lagna_matches_de440_golden() {
+    if de440_kernel::require_de440_kernel().is_none() {
+        return;
+    }
+
+    let fixture = load_fixture();
+    let app = app_router_with_api_keys(
+        de440_state_from_env().expect("DE440 state must load"),
+        [TEST_API_KEY],
+    );
+
+    let response = app
+        .oneshot(
+            authenticated_request(Method::POST, "/chart/sidereal")
+                .header("content-type", "application/json")
+                .body(Body::from(fixture.request.to_string()))
+                .expect("request must build"),
+        )
+        .await
+        .expect("response must succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.expect("body must be readable");
+    let json: Value = serde_json::from_slice(&body).expect("body must be valid json");
+
+    let lagna_deg = json["data"]["lagna"]["sidereal_longitude_deg"]
+        .as_f64()
+        .expect("lagna sidereal longitude must be numeric");
+    let lagna_rashi = json["data"]["lagna"]["rashi"].as_str().expect("lagna rashi must be present");
+
+    assert_eq!(lagna_rashi, fixture.expected_lagna_rashi);
+    let delta = (lagna_deg - fixture.expected_lagna_sidereal_longitude_deg).abs();
+    assert!(
+        delta <= fixture.tolerance_deg,
+        "lagna longitude drift: got {lagna_deg}, expected {}, delta {delta} > tolerance {}",
+        fixture.expected_lagna_sidereal_longitude_deg,
+        fixture.tolerance_deg
+    );
+}

--- a/crates/astro-core/Cargo.toml
+++ b/crates/astro-core/Cargo.toml
@@ -17,6 +17,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
+proptest.workspace = true
 serde_json.workspace = true
 
 [[bench]]

--- a/crates/astro-core/src/kernel_resolver.rs
+++ b/crates/astro-core/src/kernel_resolver.rs
@@ -290,27 +290,31 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn resolves_existing_local_kernel_path() {
-        let _guard = env_lock();
         let temp_dir =
             std::env::temp_dir().join(format!("astro-core-kernel-local-{}", std::process::id()));
         fs::create_dir_all(&temp_dir).await.expect("temp dir must exist");
         let kernel_path = temp_dir.join("de440.bsp");
         fs::write(&kernel_path, b"de440").await.expect("kernel file must be writable");
-        env::set_var(ASTRO_EPHE_PATH, &kernel_path);
-        env::remove_var(ASTRO_EPHE_GCS_URI);
+        {
+            let _guard = env_lock();
+            env::set_var(ASTRO_EPHE_PATH, &kernel_path);
+            env::remove_var(ASTRO_EPHE_GCS_URI);
+        }
 
         let resolution = resolve_kernel_from_env().await.expect("local kernel must resolve");
         assert_eq!(resolution.path, kernel_path);
         assert!(!resolution.downloaded);
 
-        env::remove_var(ASTRO_EPHE_PATH);
+        {
+            let _guard = env_lock();
+            env::remove_var(ASTRO_EPHE_PATH);
+        }
         let _ = fs::remove_file(&resolution.path).await;
         let _ = fs::remove_dir_all(&temp_dir).await;
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn reuses_cached_kernel_from_gcs_uri() {
-        let _guard = env_lock();
         let cache_dir =
             std::env::temp_dir().join(format!("astro-core-kernel-cache-{}", std::process::id()));
         let cached_kernel_path = cache_dir.join("daanyam-ephe").join("de440.bsp");
@@ -319,17 +323,23 @@ mod tests {
             .expect("cache parent must be creatable");
         fs::write(&cached_kernel_path, b"de440").await.expect("cached kernel must be writable");
 
-        env::remove_var(ASTRO_EPHE_PATH);
-        env::set_var(ASTRO_EPHE_GCS_URI, "gs://daanyam-ephe/de440.bsp");
-        env::set_var(ASTRO_EPHE_CACHE_DIR, &cache_dir);
+        {
+            let _guard = env_lock();
+            env::remove_var(ASTRO_EPHE_PATH);
+            env::set_var(ASTRO_EPHE_GCS_URI, "gs://daanyam-ephe/de440.bsp");
+            env::set_var(ASTRO_EPHE_CACHE_DIR, &cache_dir);
+        }
 
         let resolution = resolve_kernel_from_env().await.expect("cached gcs kernel must resolve");
         assert_eq!(resolution.path, cached_kernel_path);
         assert!(!resolution.downloaded);
         assert_eq!(fs::read(&resolution.path).await.expect("downloaded file must exist"), b"de440");
 
-        env::remove_var(ASTRO_EPHE_GCS_URI);
-        env::remove_var(ASTRO_EPHE_CACHE_DIR);
+        {
+            let _guard = env_lock();
+            env::remove_var(ASTRO_EPHE_GCS_URI);
+            env::remove_var(ASTRO_EPHE_CACHE_DIR);
+        }
         let _ = fs::remove_dir_all(&cache_dir).await;
     }
 }

--- a/crates/astro-core/src/lib.rs
+++ b/crates/astro-core/src/lib.rs
@@ -4,9 +4,11 @@ pub mod coords;
 pub mod de440;
 pub mod kernel_resolver;
 pub mod math;
+pub mod motion;
 pub mod time;
 
 pub use backend::*;
 pub use contracts::*;
 pub use de440::*;
 pub use kernel_resolver::*;
+pub use motion::*;

--- a/crates/astro-core/src/motion.rs
+++ b/crates/astro-core/src/motion.rs
@@ -1,0 +1,73 @@
+//! Apparent geocentric ecliptic longitude motion (speed and retrograde flag).
+
+use crate::{
+    backend::{BackendError, EphemerisBackend},
+    contracts::{CelestialBody, CoordinateFrame, EngineConfig},
+};
+
+/// Half-width of the symmetric Julian-day window used for central-difference speed.
+pub const LONGITUDE_SPEED_DELTA_DAYS: f64 = 0.5;
+
+/// Speed magnitudes below this threshold are treated as prograde (not retrograde).
+pub const RETROGRADE_SPEED_EPSILON: f64 = 1e-12;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LongitudeMotion {
+    pub longitude_speed_deg_per_day: f64,
+    pub retrograde: bool,
+}
+
+pub fn signed_longitude_delta_deg(start_deg: f64, end_deg: f64) -> f64 {
+    (end_deg - start_deg + 540.0).rem_euclid(360.0) - 180.0
+}
+
+pub fn retrograde_from_speed(speed_deg_per_day: f64) -> bool {
+    speed_deg_per_day < -RETROGRADE_SPEED_EPSILON
+}
+
+pub fn longitude_motion(
+    backend: &dyn EphemerisBackend,
+    body: CelestialBody,
+    jd_utc: f64,
+    config: &EngineConfig,
+) -> Result<LongitudeMotion, BackendError> {
+    let previous = backend.position(
+        body,
+        jd_utc - LONGITUDE_SPEED_DELTA_DAYS,
+        CoordinateFrame::EclipticGeocentric,
+        None,
+        config,
+    )?;
+    let next = backend.position(
+        body,
+        jd_utc + LONGITUDE_SPEED_DELTA_DAYS,
+        CoordinateFrame::EclipticGeocentric,
+        None,
+        config,
+    )?;
+    let delta =
+        signed_longitude_delta_deg(previous.position.longitude_deg, next.position.longitude_deg);
+    let longitude_speed_deg_per_day = delta / (LONGITUDE_SPEED_DELTA_DAYS * 2.0);
+    Ok(LongitudeMotion {
+        longitude_speed_deg_per_day,
+        retrograde: retrograde_from_speed(longitude_speed_deg_per_day),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_longitude_delta_wraps_correctly() {
+        assert!((signed_longitude_delta_deg(359.0, 1.0) - 2.0).abs() < 1e-9);
+        assert!((signed_longitude_delta_deg(1.0, 359.0) + 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn station_speed_is_not_retrograde() {
+        assert!(!retrograde_from_speed(0.0));
+        assert!(!retrograde_from_speed(1e-13));
+        assert!(retrograde_from_speed(-1e-11));
+    }
+}

--- a/crates/astro-core/tests/docs_support.rs
+++ b/crates/astro-core/tests/docs_support.rs
@@ -19,7 +19,7 @@ pub fn read_repo_doc(rel_path: &str) -> String {
 }
 
 pub fn assert_contains(haystack: &str, needle: &str) {
-    assert!(haystack.contains(needle), "expected doc content to contain: {}", needle);
+    assert!(haystack.contains(needle), "expected doc content to contain: {needle}");
 }
 
 pub fn assert_contains_all(haystack: &str, needles: &[&str]) {

--- a/crates/astro-core/tests/outer_planet_stations.rs
+++ b/crates/astro-core/tests/outer_planet_stations.rs
@@ -1,0 +1,186 @@
+//! Horizons-vetted Jupiter and Saturn station-window regressions (DE440).
+
+use astro_core::{
+    motion::{longitude_motion, LONGITUDE_SPEED_DELTA_DAYS},
+    time::julian_day,
+    CelestialBody, De440Backend, EngineConfig,
+};
+use chrono::{DateTime, TimeZone, Utc};
+use serde::Deserialize;
+use std::path::Path;
+
+#[path = "../../../tests/support/de440_kernel.rs"]
+mod de440_kernel;
+
+#[derive(Debug, Deserialize)]
+struct StationCatalog {
+    body: String,
+    #[allow(dead_code)]
+    horizons_target: String,
+    fixtures: Vec<StationFixture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StationFixture {
+    utc: String,
+    #[allow(dead_code)]
+    horizons_url: String,
+    expected_speed_sign: String,
+    station_kind: String,
+    #[allow(dead_code)]
+    tolerance_deg: f64,
+}
+
+const STATION_WINDOW_DAYS: f64 = 0.5;
+
+#[test]
+fn outer_planet_station_fixtures_match_speed_sign_contract() {
+    let Some(path) = de440_kernel::require_de440_kernel() else {
+        return;
+    };
+    let backend = De440Backend::from_path(&path).expect("DE440 backend must load");
+    let config = EngineConfig::default();
+
+    for catalog_path in [
+        "../../tests/golden/horizons_stations/jupiter.json",
+        "../../tests/golden/horizons_stations/saturn.json",
+    ] {
+        let catalog = load_catalog(catalog_path);
+        let body = parse_body(&catalog.body);
+
+        for fixture in &catalog.fixtures {
+            let jd = rfc3339_to_julian_day(&fixture.utc);
+            let motion = longitude_motion(&backend, body, jd, &config).unwrap_or_else(|err| {
+                panic!("{} {} motion failed: {err}", catalog.body, fixture.utc)
+            });
+
+            let expected_negative = fixture.expected_speed_sign == "negative";
+            assert_eq!(
+                motion.retrograde, expected_negative,
+                "{} {} retrograde flag must match expected_speed_sign={}",
+                catalog.body, fixture.utc, fixture.expected_speed_sign
+            );
+            if expected_negative {
+                assert!(
+                    motion.longitude_speed_deg_per_day < 0.0,
+                    "{} {} speed must be negative, got {}",
+                    catalog.body,
+                    fixture.utc,
+                    motion.longitude_speed_deg_per_day
+                );
+            } else {
+                assert!(
+                    motion.longitude_speed_deg_per_day > 0.0,
+                    "{} {} speed must be positive, got {}",
+                    catalog.body,
+                    fixture.utc,
+                    motion.longitude_speed_deg_per_day
+                );
+            }
+
+            assert_station_sign_flip_within_window(
+                &backend,
+                body,
+                jd,
+                &fixture.station_kind,
+                &config,
+                &catalog.body,
+                &fixture.utc,
+            );
+        }
+    }
+}
+
+fn assert_station_sign_flip_within_window(
+    backend: &De440Backend,
+    body: CelestialBody,
+    jd: f64,
+    station_kind: &str,
+    config: &EngineConfig,
+    body_name: &str,
+    utc: &str,
+) {
+    let before = longitude_motion(backend, body, jd - STATION_WINDOW_DAYS, config)
+        .expect("before-window motion");
+    let after = longitude_motion(backend, body, jd + STATION_WINDOW_DAYS, config)
+        .expect("after-window motion");
+
+    match station_kind {
+        "retrograde_entry" => {
+            assert!(
+                before.longitude_speed_deg_per_day > 0.0 && after.longitude_speed_deg_per_day < 0.0,
+                "{body_name} {utc} retrograde_entry: speed must flip + to - within ±{STATION_WINDOW_DAYS}d (before={}, after={})",
+                before.longitude_speed_deg_per_day,
+                after.longitude_speed_deg_per_day
+            );
+        }
+        "direct" => {
+            assert!(
+                before.longitude_speed_deg_per_day < 0.0 && after.longitude_speed_deg_per_day > 0.0,
+                "{body_name} {utc} direct: speed must flip - to + within ±{STATION_WINDOW_DAYS}d (before={}, after={})",
+                before.longitude_speed_deg_per_day,
+                after.longitude_speed_deg_per_day
+            );
+        }
+        other => panic!("unsupported station_kind: {other}"),
+    }
+
+    assert!(
+        (STATION_WINDOW_DAYS - LONGITUDE_SPEED_DELTA_DAYS).abs() < 1e-9,
+        "station window must match motion delta for flip semantics"
+    );
+}
+
+fn load_catalog(path: &str) -> StationCatalog {
+    let raw =
+        std::fs::read_to_string(path).unwrap_or_else(|err| panic!("{path} must exist: {err}"));
+    serde_json::from_str(&raw).unwrap_or_else(|err| panic!("{path} must parse: {err}"))
+}
+
+fn parse_body(body: &str) -> CelestialBody {
+    match body {
+        "jupiter" => CelestialBody::Jupiter,
+        "saturn" => CelestialBody::Saturn,
+        other => panic!("unsupported station catalog body: {other}"),
+    }
+}
+
+fn rfc3339_to_julian_day(timestamp: &str) -> f64 {
+    let datetime: DateTime<Utc> = timestamp.parse().expect("timestamp must parse");
+    julian_day(datetime)
+}
+
+#[test]
+fn horizons_station_fixture_files_stay_small() {
+    let root = Path::new("../../tests/golden/horizons_stations");
+    let mut total = 0u64;
+    for name in ["jupiter.json", "saturn.json"] {
+        let path = root.join(name);
+        let len = std::fs::metadata(&path)
+            .unwrap_or_else(|err| panic!("{} must exist: {err}", path.display()))
+            .len();
+        total += len;
+    }
+    assert!(
+        total < 50 * 1024,
+        "horizons_stations fixtures must stay under 50KB total, got {total} bytes"
+    );
+}
+
+#[test]
+fn station_fixture_utc_range_is_2020_through_2030() {
+    let start = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    let end = Utc.with_ymd_and_hms(2030, 12, 31, 23, 59, 59).unwrap();
+
+    for catalog_path in [
+        "../../tests/golden/horizons_stations/jupiter.json",
+        "../../tests/golden/horizons_stations/saturn.json",
+    ] {
+        let catalog = load_catalog(catalog_path);
+        for fixture in &catalog.fixtures {
+            let instant: DateTime<Utc> = fixture.utc.parse().expect("utc must parse");
+            assert!(instant >= start, "{} before 2020", fixture.utc);
+            assert!(instant <= end, "{} after 2030", fixture.utc);
+        }
+    }
+}

--- a/crates/astro-core/tests/regression_manifest.rs
+++ b/crates/astro-core/tests/regression_manifest.rs
@@ -122,8 +122,8 @@ fn adr_index_matches_adr_files() {
             .expect("ADR file stem must be valid UTF-8");
         let id = stem.split('-').next().expect("ADR stem must start with numeric identifier");
 
-        assert!(adr_index.contains(file_name), "ADR index must list file {}", file_name);
-        assert!(adr_index.contains(id), "ADR index must list ADR id {}", id);
+        assert!(adr_index.contains(file_name), "ADR index must list file {file_name}");
+        assert!(adr_index.contains(id), "ADR index must list ADR id {id}");
     }
 
     for row in &table_rows {
@@ -151,8 +151,7 @@ fn adr_index_matches_adr_files() {
             .unwrap_or(&link_target);
         assert!(
             repo_root.join(relative_path.trim_start_matches('/')).exists(),
-            "ADR index references missing file: {}",
-            link_target
+            "ADR index references missing file: {link_target}"
         );
     }
 }
@@ -172,7 +171,7 @@ fn parse_adr_index_row(line: &str) -> Option<AdrIndexRow> {
 
     let columns =
         trimmed.split('|').map(str::trim).filter(|column| !column.is_empty()).collect::<Vec<_>>();
-    assert!(columns.len() >= 4, "ADR index row must have at least four columns: {}", line);
+    assert!(columns.len() >= 4, "ADR index row must have at least four columns: {line}");
     // Parse rule: ADR ids are the leading zero-padded decimal digits from the first table column.
     let numeric_id = columns[0].parse::<u32>().unwrap_or_else(|_| {
         panic!("ADR index id must be a zero-padded decimal number: {}", columns[0])

--- a/crates/astro-core/tests/retrograde_motion_proptest.rs
+++ b/crates/astro-core/tests/retrograde_motion_proptest.rs
@@ -1,0 +1,65 @@
+//! Property: retrograde flag matches longitude speed sign (DE440, 2020–2030).
+
+use astro_core::{
+    motion::{longitude_motion, retrograde_from_speed, RETROGRADE_SPEED_EPSILON},
+    time::julian_day,
+    CelestialBody, De440Backend, EngineConfig,
+};
+use chrono::{TimeZone, Utc};
+use proptest::prelude::*;
+
+#[path = "../../../tests/support/de440_kernel.rs"]
+mod de440_kernel;
+
+const JD_2020: f64 = 2_458_866.5;
+const JD_2030_END: f64 = 2_493_019.5;
+
+fn body_strategy() -> impl Strategy<Value = CelestialBody> {
+    prop_oneof![
+        Just(CelestialBody::Mercury),
+        Just(CelestialBody::Venus),
+        Just(CelestialBody::Mars),
+        Just(CelestialBody::Jupiter),
+        Just(CelestialBody::Saturn),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 64, ..ProptestConfig::default() })]
+
+    #[test]
+    fn retrograde_iff_speed_negative_within_epsilon(
+        body in body_strategy(),
+        jd_offset in 0.0f64..(JD_2030_END - JD_2020),
+    ) {
+        let Some(path) = de440_kernel::de440_kernel_path() else {
+            return Ok(());
+        };
+        let backend = De440Backend::from_path(&path).expect("DE440 backend must load");
+        let config = EngineConfig::default();
+        let jd = JD_2020 + jd_offset;
+
+        let motion = longitude_motion(&backend, body, jd, &config)?;
+        let speed = motion.longitude_speed_deg_per_day;
+
+        if speed.abs() > RETROGRADE_SPEED_EPSILON {
+            prop_assert_eq!(motion.retrograde, retrograde_from_speed(speed));
+            prop_assert_eq!(motion.retrograde, speed < 0.0);
+        } else {
+            prop_assert!(!motion.retrograde);
+        }
+    }
+}
+
+#[test]
+fn proptest_sample_includes_known_retrograde_window() {
+    let Some(path) = de440_kernel::require_de440_kernel() else {
+        return;
+    };
+    let backend = De440Backend::from_path(&path).expect("DE440 backend must load");
+    let config = EngineConfig::default();
+    let jd = julian_day(Utc.with_ymd_and_hms(2024, 4, 10, 12, 0, 0).unwrap());
+    let motion = longitude_motion(&backend, CelestialBody::Mercury, jd, &config).expect("motion");
+    assert!(motion.retrograde);
+    assert!(motion.longitude_speed_deg_per_day < 0.0);
+}

--- a/crates/astro-vedic/src/dasha.rs
+++ b/crates/astro-vedic/src/dasha.rs
@@ -31,6 +31,27 @@ pub struct VimshottariDasha {
     pub pratyantar: DashaPeriod,
 }
 
+/// Full Vimshottari timeline for a chart.
+///
+/// Maha + Antar periods are returned for the entire 120-year cycle starting at
+/// `birth_time`. Pratyantars are returned only for the currently-active Antar
+/// (the one containing `as_of`), keeping the payload small enough for a single
+/// HTTP response without sacrificing user-visible precision.
+///
+/// Schema version: `dasha_v2`. The original `VimshottariDasha` snapshot
+/// (`dasha_v1`) remains available via the `current` field on the API payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct VimshottariTimeline {
+    /// All 9 Mahadashas, in chronological order starting from the birth Maha.
+    pub mahadashas: Vec<DashaPeriod>,
+    /// All 81 Antardashas (9 per Mahadasha), in chronological order.
+    pub antardashas: Vec<DashaPeriod>,
+    /// The 9 Pratyantars within the currently-active Antar (or empty if the
+    /// `as_of` instant falls outside the cycle, which shouldn't happen given
+    /// the 120-year span but is handled defensively).
+    pub current_antar_pratyantars: Vec<DashaPeriod>,
+}
+
 const ORDER: [DashaLord; 9] = [
     DashaLord::Ketu,
     DashaLord::Venus,
@@ -74,6 +95,97 @@ pub fn vimshottari_dasha_at(
         locate_subperiod(period_index(antar.lord), pratyantar_offset_days, antar_days, antar.start);
 
     VimshottariDasha { maha, antar, pratyantar }
+}
+
+/// Build the full Vimshottari timeline for a chart.
+///
+/// Returns:
+///   - The current snapshot (Maha + Antar + Pratyantar at `as_of`).
+///   - The full timeline (all Mahas + all Antars for the 120-yr cycle, plus
+///     Pratyantars within the current Antar).
+///
+/// The two outputs share the same period instances where they overlap, so a
+/// caller can render "current period" cards and "timeline" lists without
+/// worrying about start/end drift between them.
+pub fn vimshottari_timeline(
+    moon_sidereal_longitude_deg: f64,
+    birth_time: DateTime<Utc>,
+    as_of: DateTime<Utc>,
+) -> (VimshottariDasha, VimshottariTimeline) {
+    let division = sidereal_division(moon_sidereal_longitude_deg);
+    let start_index = nakshatra_to_dasha_index(division.nakshatra);
+
+    // Mahadashas: 9 contiguous Mahas starting from the birth nakshatra's lord.
+    let mut mahadashas = Vec::with_capacity(ORDER.len());
+    let mut cursor = birth_time;
+    for step in 0..ORDER.len() {
+        let idx = (start_index + step) % ORDER.len();
+        let duration_days = YEARS[idx] * DAYS_PER_YEAR;
+        let start = cursor;
+        let end = start + Duration::days(duration_days);
+        mahadashas.push(DashaPeriod { lord: ORDER[idx], start, end });
+        cursor = end;
+    }
+
+    // Antardashas: every Maha is sub-divided into 9 Antars. We pre-compute the
+    // full 81-period list to give Patrika rendering a single contiguous array.
+    let mut antardashas = Vec::with_capacity(ORDER.len() * ORDER.len());
+    for maha in &mahadashas {
+        let parent_days = (maha.end - maha.start).num_days();
+        let mut antar_cursor = maha.start;
+        let maha_lord_index = period_index(maha.lord);
+        for step in 0..ORDER.len() {
+            let idx = (maha_lord_index + step) % ORDER.len();
+            // For the last Antar, snap to the Maha's end so rounding errors
+            // never produce gaps or overlaps between adjacent Mahas.
+            let antar_end = if step == ORDER.len() - 1 {
+                maha.end
+            } else {
+                antar_cursor + Duration::days(subperiod_duration_days(parent_days, YEARS[idx]))
+            };
+            antardashas.push(DashaPeriod {
+                lord: ORDER[idx],
+                start: antar_cursor,
+                end: antar_end,
+            });
+            antar_cursor = antar_end;
+        }
+    }
+
+    // Resolve the current Maha + Antar + Pratyantar using the existing snapshot
+    // function. This guarantees the current period objects are byte-identical
+    // to one of the entries in `mahadashas` / `antardashas` (modulo the final
+    // Antar's snap-to-end), so consumers can compare by (lord, start) keys.
+    let current = vimshottari_dasha_at(moon_sidereal_longitude_deg, birth_time, as_of);
+
+    // Pratyantars: derive only for the current Antar (full cycle would be 729
+    // entries, an order of magnitude more than the consumer needs today).
+    let mut current_antar_pratyantars = Vec::with_capacity(ORDER.len());
+    let antar_days = (current.antar.end - current.antar.start).num_days();
+    let mut pratyantar_cursor = current.antar.start;
+    let antar_lord_index = period_index(current.antar.lord);
+    for step in 0..ORDER.len() {
+        let idx = (antar_lord_index + step) % ORDER.len();
+        let pratyantar_end = if step == ORDER.len() - 1 {
+            current.antar.end
+        } else {
+            pratyantar_cursor + Duration::days(subperiod_duration_days(antar_days, YEARS[idx]))
+        };
+        current_antar_pratyantars.push(DashaPeriod {
+            lord: ORDER[idx],
+            start: pratyantar_cursor,
+            end: pratyantar_end,
+        });
+        pratyantar_cursor = pratyantar_end;
+    }
+
+    let timeline = VimshottariTimeline {
+        mahadashas,
+        antardashas,
+        current_antar_pratyantars,
+    };
+
+    (current, timeline)
 }
 
 fn locate_period(
@@ -178,5 +290,81 @@ mod tests {
         assert_eq!(dasha.pratyantar.lord, DashaLord::Jupiter);
         assert!(dasha.maha.start <= as_of);
         assert!(dasha.maha.end > as_of);
+    }
+
+    #[test]
+    fn timeline_has_nine_mahadashas_in_birth_order() {
+        let birth_time = Utc.with_ymd_and_hms(2000, 1, 1, 12, 0, 0).unwrap();
+        let as_of = Utc.with_ymd_and_hms(2005, 1, 1, 12, 0, 0).unwrap();
+        let (_current, timeline) =
+            vimshottari_timeline(99.586_412_769_677_72, birth_time, as_of);
+
+        assert_eq!(timeline.mahadashas.len(), 9);
+        // Mahas must be contiguous in time.
+        for pair in timeline.mahadashas.windows(2) {
+            assert_eq!(pair[0].end, pair[1].start);
+        }
+        // First Maha starts at birth.
+        assert_eq!(timeline.mahadashas[0].start, birth_time);
+        // Total cycle length is 120 years.
+        let last_end = timeline.mahadashas.last().unwrap().end;
+        let cycle_days = (last_end - birth_time).num_days();
+        assert_eq!(cycle_days, 120 * 365);
+    }
+
+    #[test]
+    fn timeline_antars_form_contiguous_eighty_one_period_sequence() {
+        let birth_time = Utc.with_ymd_and_hms(1990, 6, 15, 0, 0, 0).unwrap();
+        let as_of = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let (_current, timeline) = vimshottari_timeline(180.0, birth_time, as_of);
+
+        assert_eq!(timeline.antardashas.len(), 9 * 9);
+        // Each block of 9 Antars must fit exactly inside the corresponding Maha.
+        for (maha_index, maha) in timeline.mahadashas.iter().enumerate() {
+            let block = &timeline.antardashas[maha_index * 9..(maha_index + 1) * 9];
+            assert_eq!(block.first().unwrap().start, maha.start);
+            assert_eq!(block.last().unwrap().end, maha.end);
+            // First Antar of any Maha is ruled by the Maha lord itself.
+            assert_eq!(block.first().unwrap().lord, maha.lord);
+        }
+    }
+
+    #[test]
+    fn timeline_pratyantars_cover_current_antar_exactly() {
+        let birth_time = Utc.with_ymd_and_hms(1985, 9, 20, 5, 30, 0).unwrap();
+        let as_of = Utc.with_ymd_and_hms(2026, 5, 11, 0, 0, 0).unwrap();
+        let (current, timeline) = vimshottari_timeline(245.7, birth_time, as_of);
+
+        assert_eq!(timeline.current_antar_pratyantars.len(), 9);
+        // First Pratyantar is the Antar lord itself.
+        assert_eq!(
+            timeline.current_antar_pratyantars.first().unwrap().lord,
+            current.antar.lord
+        );
+        // Pratyantars must tile the current Antar exactly.
+        assert_eq!(
+            timeline.current_antar_pratyantars.first().unwrap().start,
+            current.antar.start
+        );
+        assert_eq!(
+            timeline.current_antar_pratyantars.last().unwrap().end,
+            current.antar.end
+        );
+        for pair in timeline.current_antar_pratyantars.windows(2) {
+            assert_eq!(pair[0].end, pair[1].start);
+        }
+    }
+
+    #[test]
+    fn timeline_current_matches_snapshot() {
+        // The (Maha, Antar) returned by the timeline's "current" must match
+        // what vimshottari_dasha_at returns standalone for the same as_of.
+        let birth_time = Utc.with_ymd_and_hms(2000, 1, 1, 12, 0, 0).unwrap();
+        let as_of = Utc.with_ymd_and_hms(2005, 1, 1, 12, 0, 0).unwrap();
+        let standalone = vimshottari_dasha_at(99.586_412_769_677_72, birth_time, as_of);
+        let (current, _) = vimshottari_timeline(99.586_412_769_677_72, birth_time, as_of);
+        assert_eq!(standalone.maha.lord, current.maha.lord);
+        assert_eq!(standalone.antar.lord, current.antar.lord);
+        assert_eq!(standalone.pratyantar.lord, current.pratyantar.lord);
     }
 }

--- a/crates/astro-vedic/src/dasha.rs
+++ b/crates/astro-vedic/src/dasha.rs
@@ -143,11 +143,7 @@ pub fn vimshottari_timeline(
             } else {
                 antar_cursor + Duration::days(subperiod_duration_days(parent_days, YEARS[idx]))
             };
-            antardashas.push(DashaPeriod {
-                lord: ORDER[idx],
-                start: antar_cursor,
-                end: antar_end,
-            });
+            antardashas.push(DashaPeriod { lord: ORDER[idx], start: antar_cursor, end: antar_end });
             antar_cursor = antar_end;
         }
     }
@@ -179,11 +175,7 @@ pub fn vimshottari_timeline(
         pratyantar_cursor = pratyantar_end;
     }
 
-    let timeline = VimshottariTimeline {
-        mahadashas,
-        antardashas,
-        current_antar_pratyantars,
-    };
+    let timeline = VimshottariTimeline { mahadashas, antardashas, current_antar_pratyantars };
 
     (current, timeline)
 }
@@ -296,8 +288,7 @@ mod tests {
     fn timeline_has_nine_mahadashas_in_birth_order() {
         let birth_time = Utc.with_ymd_and_hms(2000, 1, 1, 12, 0, 0).unwrap();
         let as_of = Utc.with_ymd_and_hms(2005, 1, 1, 12, 0, 0).unwrap();
-        let (_current, timeline) =
-            vimshottari_timeline(99.586_412_769_677_72, birth_time, as_of);
+        let (_current, timeline) = vimshottari_timeline(99.586_412_769_677_72, birth_time, as_of);
 
         assert_eq!(timeline.mahadashas.len(), 9);
         // Mahas must be contiguous in time.
@@ -337,19 +328,10 @@ mod tests {
 
         assert_eq!(timeline.current_antar_pratyantars.len(), 9);
         // First Pratyantar is the Antar lord itself.
-        assert_eq!(
-            timeline.current_antar_pratyantars.first().unwrap().lord,
-            current.antar.lord
-        );
+        assert_eq!(timeline.current_antar_pratyantars.first().unwrap().lord, current.antar.lord);
         // Pratyantars must tile the current Antar exactly.
-        assert_eq!(
-            timeline.current_antar_pratyantars.first().unwrap().start,
-            current.antar.start
-        );
-        assert_eq!(
-            timeline.current_antar_pratyantars.last().unwrap().end,
-            current.antar.end
-        );
+        assert_eq!(timeline.current_antar_pratyantars.first().unwrap().start, current.antar.start);
+        assert_eq!(timeline.current_antar_pratyantars.last().unwrap().end, current.antar.end);
         for pair in timeline.current_antar_pratyantars.windows(2) {
             assert_eq!(pair[0].end, pair[1].start);
         }

--- a/crates/astro-vedic/src/lib.rs
+++ b/crates/astro-vedic/src/lib.rs
@@ -2,8 +2,13 @@ mod ayanamsa;
 mod dasha;
 mod sidereal;
 mod vargas;
+mod yogas;
 
 pub use ayanamsa::*;
 pub use dasha::*;
 pub use sidereal::*;
 pub use vargas::*;
+pub use yogas::{
+    all_yoga_keys, detect_yogas, DetectedYoga, PlanetHouses, PlanetLongitudes, Yoga,
+    YogaChartFacts,
+};

--- a/crates/astro-vedic/src/lib.rs
+++ b/crates/astro-vedic/src/lib.rs
@@ -9,6 +9,5 @@ pub use dasha::*;
 pub use sidereal::*;
 pub use vargas::*;
 pub use yogas::{
-    all_yoga_keys, detect_yogas, DetectedYoga, PlanetHouses, PlanetLongitudes, Yoga,
-    YogaChartFacts,
+    all_yoga_keys, detect_yogas, DetectedYoga, PlanetHouses, PlanetLongitudes, Yoga, YogaChartFacts,
 };

--- a/crates/astro-vedic/src/yogas/chandra_mangal.rs
+++ b/crates/astro-vedic/src/yogas/chandra_mangal.rs
@@ -1,0 +1,94 @@
+//! Chandra-Mangal Yoga
+//!
+//! Classical: Moon and Mars conjunct in the same rashi. Associated with
+//! financial mobility, entrepreneurial drive — but also temperamental
+//! restlessness when not directed.
+
+use super::{DetectedYoga, Yoga, YogaChartFacts};
+
+pub struct ChandraMangal;
+
+impl Yoga for ChandraMangal {
+    fn key(&self) -> &'static str {
+        "chandra_mangal"
+    }
+
+    fn detect(&self, facts: &YogaChartFacts) -> Option<DetectedYoga> {
+        let moon_house = facts.planet_houses.moon?;
+        let mars_house = facts.planet_houses.mars?;
+        let moon_lon = facts.planet_longitudes.moon?;
+        let mars_lon = facts.planet_longitudes.mars?;
+
+        if moon_house != mars_house {
+            return None;
+        }
+
+        // Same-rashi conjunction. Mark strength higher when the angular
+        // separation is tight (<= 10°), lower when wider.
+        let sep = (moon_lon - mars_lon).abs().min(360.0 - (moon_lon - mars_lon).abs());
+        let strength = if sep <= 10.0 {
+            1.0
+        } else if sep <= 20.0 {
+            0.75
+        } else {
+            0.5
+        };
+
+        Some(DetectedYoga {
+            key: "chandra_mangal".to_string(),
+            name: "Chandra-Mangal Yoga".to_string(),
+            planets_involved: vec!["Moon".to_string(), "Mars".to_string()],
+            houses_involved: vec![moon_house],
+            strength,
+            voice_line: "Moon and Mars meet in the same sign — the chart carries entrepreneurial fire; spend the heat on what is worth the burn.".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{PlanetHouses, PlanetLongitudes, YogaChartFacts};
+    use super::*;
+    use crate::Rashi;
+
+    fn facts_for_same_house(
+        moon_house: u8,
+        mars_house: u8,
+        moon_lon: f64,
+        mars_lon: f64,
+    ) -> YogaChartFacts {
+        YogaChartFacts {
+            lagna_rashi: Rashi::Mesha,
+            planet_longitudes: PlanetLongitudes {
+                moon: Some(moon_lon),
+                mars: Some(mars_lon),
+                ..Default::default()
+            },
+            planet_houses: PlanetHouses {
+                moon: Some(moon_house),
+                mars: Some(mars_house),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn detects_tight_conjunction_at_full_strength() {
+        let facts = facts_for_same_house(5, 5, 100.0, 103.0);
+        let yoga = ChandraMangal.detect(&facts).expect("must detect");
+        assert!((yoga.strength - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn detects_wider_conjunction_at_lower_strength() {
+        let facts = facts_for_same_house(5, 5, 100.0, 115.0);
+        let yoga = ChandraMangal.detect(&facts).expect("must detect");
+        assert!((yoga.strength - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rejects_when_planets_in_different_houses() {
+        let facts = facts_for_same_house(5, 6, 100.0, 130.0);
+        assert!(ChandraMangal.detect(&facts).is_none());
+    }
+}

--- a/crates/astro-vedic/src/yogas/gajakesari.rs
+++ b/crates/astro-vedic/src/yogas/gajakesari.rs
@@ -1,0 +1,80 @@
+//! Gajakesari Yoga
+//!
+//! Classical: Moon and Jupiter in mutual kendra (1, 4, 7, or 10 from each
+//! other). Bestows fame, intelligence, eloquence, longevity per Phaladeepika.
+//!
+//! Modern strength considerations (not all gating; we soften the voice via
+//! `strength` instead of failing the detection):
+//!   - Jupiter retrograde reduces strength slightly.
+//!   - Moon waning (less than 90° from Sun on the dark side) reduces strength.
+//!     (Phase 4 first iteration ignores this; Phase 4.1 may grade it in.)
+
+use super::{is_mutual_kendra, DetectedYoga, Yoga, YogaChartFacts};
+
+pub struct Gajakesari;
+
+impl Yoga for Gajakesari {
+    fn key(&self) -> &'static str {
+        "gajakesari"
+    }
+
+    fn detect(&self, facts: &YogaChartFacts) -> Option<DetectedYoga> {
+        let moon_house = facts.planet_houses.moon?;
+        let jupiter_house = facts.planet_houses.jupiter?;
+
+        if !is_mutual_kendra(moon_house, jupiter_house) {
+            return None;
+        }
+
+        Some(DetectedYoga {
+            key: "gajakesari".to_string(),
+            name: "Gajakesari Yoga".to_string(),
+            planets_involved: vec!["Moon".to_string(), "Jupiter".to_string()],
+            houses_involved: vec![moon_house, jupiter_house],
+            strength: 1.0,
+            voice_line: "Moon and Jupiter sit in mutual kendra — the chart asks you to speak from a steady inner ground; the world tends to listen.".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{PlanetHouses, PlanetLongitudes, YogaChartFacts};
+    use super::*;
+    use crate::Rashi;
+
+    fn facts_with_moon_jupiter(moon_house: u8, jupiter_house: u8) -> YogaChartFacts {
+        YogaChartFacts {
+            lagna_rashi: Rashi::Mesha,
+            planet_longitudes: PlanetLongitudes::default(),
+            planet_houses: PlanetHouses {
+                moon: Some(moon_house),
+                jupiter: Some(jupiter_house),
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn detects_when_moon_and_jupiter_are_in_kendra() {
+        // Moon in 1st, Jupiter in 10th — classic Gajakesari
+        let facts = facts_with_moon_jupiter(1, 10);
+        let yoga = Gajakesari.detect(&facts).expect("must detect");
+        assert_eq!(yoga.key, "gajakesari");
+        assert_eq!(yoga.houses_involved, vec![1, 10]);
+    }
+
+    #[test]
+    fn rejects_when_outside_kendra() {
+        // Moon in 1st, Jupiter in 2nd — not a kendra distance
+        let facts = facts_with_moon_jupiter(1, 2);
+        assert!(Gajakesari.detect(&facts).is_none());
+    }
+
+    #[test]
+    fn rejects_when_moon_or_jupiter_missing() {
+        let mut facts = facts_with_moon_jupiter(1, 1);
+        facts.planet_houses.jupiter = None;
+        assert!(Gajakesari.detect(&facts).is_none());
+    }
+}

--- a/crates/astro-vedic/src/yogas/mod.rs
+++ b/crates/astro-vedic/src/yogas/mod.rs
@@ -1,0 +1,130 @@
+//! Classical Vedic yoga detection — Phase 4 (engine v0.18+).
+//!
+//! Status: SCAFFOLD. Two example yogas are implemented as a pattern
+//! (Gajakesari, Chandra-Mangal) and serve as the template for the remaining
+//! 28+ yogas listed in `docs/engine/yogas-roadmap.md`. Each yoga is added by:
+//!
+//!   1. Creating `yogas/<yoga_name>.rs` that implements the `Yoga` trait.
+//!   2. Registering the detector in `registry::all_yogas()`.
+//!   3. Adding a golden-file test against a known chart in
+//!      `tests/golden/yogas_<chart_name>.json`.
+//!
+//! Voice rules: each detected yoga returns a Daanyam-voice short description
+//! suitable for inline rendering on the explainer + Patrika. No prediction;
+//! Sanskrit nouns + everyday English verbs (see V3 strategy doc).
+
+use serde::{Deserialize, Serialize};
+
+use crate::Rashi;
+
+mod chandra_mangal;
+mod gajakesari;
+mod registry;
+
+pub use registry::{detect_yogas, all_yoga_keys};
+
+/// A single detected yoga (or absence thereof at low strength).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DetectedYoga {
+    /// Stable machine key, snake_case (e.g. "gajakesari", "chandra_mangal").
+    pub key: String,
+    /// Human-readable Sanskrit-rooted name.
+    pub name: String,
+    /// Planets that triggered the detection.
+    pub planets_involved: Vec<String>,
+    /// Houses (1-12) the planets sit in, when relevant.
+    pub houses_involved: Vec<u8>,
+    /// 0.0–1.0 confidence in the detection. 1.0 = textbook formation; lower
+    /// values mark partial / probational forms that still pass the detector
+    /// but warrant softer voice in the rendered Patrika.
+    pub strength: f64,
+    /// Daanyam-voice one-line description, ready for inline rendering.
+    pub voice_line: String,
+}
+
+/// Minimal chart facts a yoga detector reads from. Constructed once per chart
+/// request inside the API handler and passed by reference to every detector,
+/// so each one stays O(N) in the chart size and tests can spin up fakes
+/// without touching ephemeris code.
+#[derive(Debug, Clone)]
+pub struct YogaChartFacts {
+    pub lagna_rashi: Rashi,
+    /// Sidereal longitude (0..360) of each graha. None for grahas not computed.
+    pub planet_longitudes: PlanetLongitudes,
+    /// House number (1..12, whole-sign) for each graha.
+    pub planet_houses: PlanetHouses,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PlanetLongitudes {
+    pub sun: Option<f64>,
+    pub moon: Option<f64>,
+    pub mars: Option<f64>,
+    pub mercury: Option<f64>,
+    pub jupiter: Option<f64>,
+    pub venus: Option<f64>,
+    pub saturn: Option<f64>,
+    pub rahu: Option<f64>,
+    pub ketu: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PlanetHouses {
+    pub sun: Option<u8>,
+    pub moon: Option<u8>,
+    pub mars: Option<u8>,
+    pub mercury: Option<u8>,
+    pub jupiter: Option<u8>,
+    pub venus: Option<u8>,
+    pub saturn: Option<u8>,
+    pub rahu: Option<u8>,
+    pub ketu: Option<u8>,
+}
+
+/// Trait every individual yoga detector implements. The registry collects
+/// trait objects and runs them in a fixed order so the response order is
+/// stable across requests.
+pub trait Yoga: Send + Sync {
+    fn key(&self) -> &'static str;
+    fn detect(&self, facts: &YogaChartFacts) -> Option<DetectedYoga>;
+}
+
+// ─── Helpers used by multiple detectors ─────────────────────────────────────
+
+/// Rashi distance from `from` to `to`, counting `from` itself as 1
+/// (Vedic convention). Returns 1..=12.
+pub(crate) fn rashi_distance(from: Rashi, to: Rashi) -> u8 {
+    let a = rashi_index(from) as i16;
+    let b = rashi_index(to) as i16;
+    ((b - a).rem_euclid(12) + 1) as u8
+}
+
+pub(crate) fn rashi_index(r: Rashi) -> u8 {
+    match r {
+        Rashi::Mesha => 0,
+        Rashi::Vrishabha => 1,
+        Rashi::Mithuna => 2,
+        Rashi::Karka => 3,
+        Rashi::Simha => 4,
+        Rashi::Kanya => 5,
+        Rashi::Tula => 6,
+        Rashi::Vrischika => 7,
+        Rashi::Dhanu => 8,
+        Rashi::Makara => 9,
+        Rashi::Kumbha => 10,
+        Rashi::Meena => 11,
+    }
+}
+
+/// House distance (1..=12), counting `from` as 1.
+pub(crate) fn house_distance(from: u8, to: u8) -> u8 {
+    let a = from as i16 - 1;
+    let b = to as i16 - 1;
+    ((b - a).rem_euclid(12) + 1) as u8
+}
+
+/// True if `a` and `b` are mutually kendra (1, 4, 7, 10 from each other).
+pub(crate) fn is_mutual_kendra(a: u8, b: u8) -> bool {
+    let d = house_distance(a, b);
+    matches!(d, 1 | 4 | 7 | 10)
+}

--- a/crates/astro-vedic/src/yogas/mod.rs
+++ b/crates/astro-vedic/src/yogas/mod.rs
@@ -21,7 +21,7 @@ mod chandra_mangal;
 mod gajakesari;
 mod registry;
 
-pub use registry::{detect_yogas, all_yoga_keys};
+pub use registry::{all_yoga_keys, detect_yogas};
 
 /// A single detected yoga (or absence thereof at low strength).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -93,12 +93,14 @@ pub trait Yoga: Send + Sync {
 
 /// Rashi distance from `from` to `to`, counting `from` itself as 1
 /// (Vedic convention). Returns 1..=12.
+#[allow(dead_code)]
 pub(crate) fn rashi_distance(from: Rashi, to: Rashi) -> u8 {
     let a = rashi_index(from) as i16;
     let b = rashi_index(to) as i16;
     ((b - a).rem_euclid(12) + 1) as u8
 }
 
+#[allow(dead_code)]
 pub(crate) fn rashi_index(r: Rashi) -> u8 {
     match r {
         Rashi::Mesha => 0,

--- a/crates/astro-vedic/src/yogas/registry.rs
+++ b/crates/astro-vedic/src/yogas/registry.rs
@@ -1,0 +1,72 @@
+//! Yoga registry — collects every implemented yoga and runs them in a
+//! stable order so API responses are deterministic.
+
+use super::{chandra_mangal::ChandraMangal, gajakesari::Gajakesari};
+use super::{DetectedYoga, Yoga, YogaChartFacts};
+
+/// Stable list of all yoga keys recognised by this engine version.
+/// Used in the OpenAPI schema and for client-side filter/sort.
+pub fn all_yoga_keys() -> Vec<&'static str> {
+    vec![
+        Gajakesari.key(),
+        ChandraMangal.key(),
+        // 28+ more yoga keys go here as detectors are added — see
+        // docs/engine/yogas-roadmap.md for the priority-ordered list.
+    ]
+}
+
+/// Run every detector against the chart facts. Returns only the detected
+/// yogas (None results are dropped). Order is stable across requests.
+pub fn detect_yogas(facts: &YogaChartFacts) -> Vec<DetectedYoga> {
+    let detectors: Vec<Box<dyn Yoga>> = vec![
+        Box::new(Gajakesari),
+        Box::new(ChandraMangal),
+    ];
+
+    detectors
+        .into_iter()
+        .filter_map(|d| d.detect(facts))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{PlanetHouses, PlanetLongitudes, YogaChartFacts};
+    use super::*;
+    use crate::Rashi;
+
+    #[test]
+    fn registry_returns_only_detected_yogas() {
+        let facts = YogaChartFacts {
+            lagna_rashi: Rashi::Karka,
+            planet_longitudes: PlanetLongitudes {
+                moon: Some(100.0),
+                mars: Some(102.0),
+                jupiter: Some(280.0),
+                ..Default::default()
+            },
+            planet_houses: PlanetHouses {
+                moon: Some(1),
+                mars: Some(1),
+                jupiter: Some(7),
+                ..Default::default()
+            },
+        };
+        let yogas = detect_yogas(&facts);
+        // Moon in 1, Jupiter in 7 → Gajakesari; Moon+Mars in same house → Chandra-Mangal.
+        let keys: Vec<&str> = yogas.iter().map(|y| y.key.as_str()).collect();
+        assert!(keys.contains(&"gajakesari"));
+        assert!(keys.contains(&"chandra_mangal"));
+    }
+
+    #[test]
+    fn registry_returns_empty_when_no_yogas_apply() {
+        let facts = YogaChartFacts {
+            lagna_rashi: Rashi::Mesha,
+            planet_longitudes: PlanetLongitudes::default(),
+            planet_houses: PlanetHouses::default(),
+        };
+        let yogas = detect_yogas(&facts);
+        assert!(yogas.is_empty());
+    }
+}

--- a/crates/astro-vedic/src/yogas/registry.rs
+++ b/crates/astro-vedic/src/yogas/registry.rs
@@ -18,15 +18,9 @@ pub fn all_yoga_keys() -> Vec<&'static str> {
 /// Run every detector against the chart facts. Returns only the detected
 /// yogas (None results are dropped). Order is stable across requests.
 pub fn detect_yogas(facts: &YogaChartFacts) -> Vec<DetectedYoga> {
-    let detectors: Vec<Box<dyn Yoga>> = vec![
-        Box::new(Gajakesari),
-        Box::new(ChandraMangal),
-    ];
+    let detectors: Vec<Box<dyn Yoga>> = vec![Box::new(Gajakesari), Box::new(ChandraMangal)];
 
-    detectors
-        .into_iter()
-        .filter_map(|d| d.detect(facts))
-        .collect()
+    detectors.into_iter().filter_map(|d| d.detect(facts)).collect()
 }
 
 #[cfg(test)]

--- a/deploy/cloud_run.yaml
+++ b/deploy/cloud_run.yaml
@@ -1,0 +1,57 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: astro-engine
+  annotations:
+    run.googleapis.com/launch-stage: GA
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "10"
+        run.googleapis.com/execution-environment: gen2
+    spec:
+      containerConcurrency: 40
+      timeoutSeconds: 60
+      containers:
+        - image: IMAGE_URI_PLACEHOLDER
+          ports:
+            - name: http1
+              containerPort: 3000
+          env:
+            - name: HOST
+              value: 0.0.0.0
+            - name: ASTRO_ENGINE_BACKEND
+              value: de440
+            - name: ASTRO_BACKEND
+              value: de440
+            - name: KERNEL_GCS_URI
+              value: gs://daanyam-astroengine-kernels/de440.bsp
+            - name: ASTRO_EPHE_PATH
+              value: gs://daanyam-astroengine-kernels/de440.bsp
+            - name: ASTRO_EPHE_CACHE_DIR
+              value: /tmp/ephe
+            - name: ENVIRONMENT
+              value: production
+            - name: RUST_LOG
+              value: info
+            # METRICS_TOKEN: set via Secret Manager for GET /metrics (see docs/deploy.md).
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+          startupProbe:
+            timeoutSeconds: 5
+            periodSeconds: 10
+            failureThreshold: 12
+            httpGet:
+              path: /health
+              port: 3000
+          livenessProbe:
+            timeoutSeconds: 5
+            periodSeconds: 20
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 3000

--- a/deploy/cloudrun/alert-policies/uptime_failure.json.tmpl
+++ b/deploy/cloudrun/alert-policies/uptime_failure.json.tmpl
@@ -27,9 +27,9 @@
         ],
         "comparison": "COMPARISON_GT",
         "thresholdValue": 1,
-        "duration": "0s",
+        "duration": "60s",
         "trigger": {
-          "count": 1
+          "count": __UPTIME_CONSECUTIVE_FAILURES__
         }
       }
     }

--- a/deploy/cloudrun/post_deploy_verify.sh
+++ b/deploy/cloudrun/post_deploy_verify.sh
@@ -34,7 +34,8 @@ if [[ -z "${SERVICE_URL}" ]]; then
   exit 1
 fi
 
-UPTIME_DISPLAY_NAME="${UPTIME_DISPLAY_NAME:-${SERVICE_NAME} health}"
+UPTIME_DISPLAY_NAME="${UPTIME_DISPLAY_NAME:-${SERVICE_NAME} health (multi-region)}"
+UPTIME_REGIONS="${UPTIME_REGIONS:-asia-southeast1,usa-iowa,europe-west1}"
 UPTIME_POLICY_DISPLAY_NAME="${UPTIME_POLICY_DISPLAY_NAME:-${SERVICE_NAME} uptime failure}"
 ERROR_POLICY_DISPLAY_NAME="${ERROR_POLICY_DISPLAY_NAME:-${SERVICE_NAME} 5xx count}"
 LATENCY_POLICY_DISPLAY_NAME="${LATENCY_POLICY_DISPLAY_NAME:-${SERVICE_NAME} p95 latency}"
@@ -54,6 +55,22 @@ UPTIME_CHECK_NAME="$(gcloud monitoring uptime list-configs \
 if [[ -z "${UPTIME_CHECK_NAME}" ]]; then
   echo "missing uptime check: ${UPTIME_DISPLAY_NAME}" >&2
   exit 1
+fi
+
+echo "Verifying multi-region uptime probe regions"
+UPTIME_REGIONS_ACTUAL="$(gcloud monitoring uptime describe "${UPTIME_CHECK_NAME}" \
+  --project "${PROJECT_ID}" \
+  --format='value(selectedRegions)' 2>/dev/null || true)"
+if [[ -z "${UPTIME_REGIONS_ACTUAL}" ]]; then
+  echo "warning: could not read uptime check regions; expected ${UPTIME_REGIONS}" >&2
+else
+  for region in ${UPTIME_REGIONS//,/ }; do
+    if [[ "${UPTIME_REGIONS_ACTUAL}" != *"${region}"* ]]; then
+      echo "uptime check missing region ${region} (have: ${UPTIME_REGIONS_ACTUAL})" >&2
+      exit 1
+    fi
+  done
+  echo "- regions: ${UPTIME_REGIONS_ACTUAL}"
 fi
 
 echo "Checking alert policies"

--- a/deploy/cloudrun/setup_monitoring.sh
+++ b/deploy/cloudrun/setup_monitoring.sh
@@ -20,7 +20,9 @@ SERVICE_NAME="${SERVICE_NAME:-astro-api}"
 REGION="${REGION:-asia-south1}"
 SERVICE_URL="${SERVICE_URL:-}"
 SERVICE_HOST="${SERVICE_HOST:-}"
-UPTIME_CHECK_PERIOD="${UPTIME_CHECK_PERIOD:-1}"
+UPTIME_CHECK_PERIOD="${UPTIME_CHECK_PERIOD:-60s}"
+UPTIME_REGIONS="${UPTIME_REGIONS:-asia-southeast1,usa-iowa,europe-west1}"
+UPTIME_CONSECUTIVE_FAILURES="${UPTIME_CONSECUTIVE_FAILURES:-2}"
 ERROR_COUNT_THRESHOLD="${ERROR_COUNT_THRESHOLD:-5}"
 LATENCY_THRESHOLD_MS="${LATENCY_THRESHOLD_MS:-1500}"
 NOTIFICATION_CHANNELS="${NOTIFICATION_CHANNELS:-}"
@@ -48,7 +50,7 @@ if [[ -z "${SERVICE_HOST}" ]]; then
   SERVICE_HOST="${SERVICE_HOST%%/*}"
 fi
 
-UPTIME_DISPLAY_NAME="${UPTIME_DISPLAY_NAME:-${SERVICE_NAME} health}"
+UPTIME_DISPLAY_NAME="${UPTIME_DISPLAY_NAME:-${SERVICE_NAME} health (multi-region)}"
 UPTIME_POLICY_DISPLAY_NAME="${UPTIME_POLICY_DISPLAY_NAME:-${SERVICE_NAME} uptime failure}"
 ERROR_POLICY_DISPLAY_NAME="${ERROR_POLICY_DISPLAY_NAME:-${SERVICE_NAME} 5xx count}"
 LATENCY_POLICY_DISPLAY_NAME="${LATENCY_POLICY_DISPLAY_NAME:-${SERVICE_NAME} p95 latency}"
@@ -102,7 +104,7 @@ ensure_uptime_check() {
       --status-classes=2xx \
       --period="${UPTIME_CHECK_PERIOD}" \
       --timeout=10 \
-      --regions=usa-iowa,usa-oregon,usa-virginia \
+      --regions="${UPTIME_REGIONS}" \
       --validate-ssl=true
     existing_name="$(lookup_uptime_check_name | head -n1)"
   else
@@ -113,7 +115,7 @@ ensure_uptime_check() {
       --set-status-classes=2xx \
       --period="${UPTIME_CHECK_PERIOD}" \
       --timeout=10 \
-      --set-regions=usa-iowa,usa-oregon,usa-virginia \
+      --set-regions="${UPTIME_REGIONS}" \
       --clear-status-codes=true \
       --validate-ssl=true
   fi
@@ -141,6 +143,7 @@ render_policy() {
     -e "s|__UPTIME_CHECK_ID__|$(json_escape "${uptime_check_id}")|g" \
     -e "s|__ERROR_COUNT_THRESHOLD__|${ERROR_COUNT_THRESHOLD}|g" \
     -e "s|__LATENCY_THRESHOLD_MS__|${LATENCY_THRESHOLD_MS}|g" \
+    -e "s|__UPTIME_CONSECUTIVE_FAILURES__|${UPTIME_CONSECUTIVE_FAILURES}|g" \
     -e "s|__NOTIFICATION_CHANNELS__|$(json_escape "${channels_json}")|g" \
     "${template_path}" > "${output_path}"
 }

--- a/dist/openapi.json
+++ b/dist/openapi.json
@@ -504,6 +504,45 @@
         },
         "type": "object"
       },
+      "ProvenanceResponse": {
+        "properties": {
+          "ayanamsa_used": {
+            "type": "string"
+          },
+          "engine_mode": {
+            "type": "string"
+          },
+          "engine_semantic_version": {
+            "type": "string"
+          },
+          "gravitational_deflection": {
+            "type": "boolean"
+          },
+          "house_system": {
+            "type": "string"
+          },
+          "kernel_hash": {
+            "type": "string"
+          },
+          "kernel_load_seconds": {
+            "type": "number"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "engine_semantic_version",
+          "version",
+          "engine_mode",
+          "ayanamsa_used",
+          "house_system",
+          "gravitational_deflection",
+          "kernel_hash",
+          "kernel_load_seconds"
+        ],
+        "type": "object"
+      },
       "ResultMetadata": {
         "properties": {
           "ayanamsa_used": {
@@ -801,6 +840,38 @@
         },
         "type": "object"
       },
+      "VimshottariTimeline": {
+        "description": "Full Vimshottari timeline (dasha_v2). Returned when include_timeline=true on POST /dasha.",
+        "properties": {
+          "antardashas": {
+            "description": "81 Antardashas (9 per Maha) in chronological order.",
+            "items": {
+              "$ref": "#/components/schemas/DashaPeriod"
+            },
+            "type": "array"
+          },
+          "current_antar_pratyantars": {
+            "description": "9 Pratyantars within the currently-active Antar.",
+            "items": {
+              "$ref": "#/components/schemas/DashaPeriod"
+            },
+            "type": "array"
+          },
+          "mahadashas": {
+            "description": "9 Mahadashas spanning the 120-yr cycle from birth_time.",
+            "items": {
+              "$ref": "#/components/schemas/DashaPeriod"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "mahadashas",
+          "antardashas",
+          "current_antar_pratyantars"
+        ],
+        "type": "object"
+      },
       "WholeSignHouse": {
         "properties": {
           "cusp_sidereal_longitude_deg": {
@@ -940,6 +1011,23 @@
           }
         ],
         "summary": "Compute Lahiri sidereal positions"
+      }
+    },
+    "/provenance": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProvenanceResponse"
+                }
+              }
+            },
+            "description": "Provenance payload"
+          }
+        },
+        "summary": "Return engine runtime provenance metadata"
       }
     }
   }

--- a/dist/openapi.json
+++ b/dist/openapi.json
@@ -506,13 +506,36 @@
       },
       "ProvenanceResponse": {
         "properties": {
+          "ayanamsa_algorithm": {
+            "example": "lahiri_swe_zero_epoch_iau1976_v1",
+            "type": "string"
+          },
+          "ayanamsa_id": {
+            "example": "lahiri",
+            "type": "string"
+          },
           "ayanamsa_used": {
+            "type": "string"
+          },
+          "ayanamsa_version": {
+            "example": "lahiri_swe_zero_epoch_iau1976_v1",
+            "type": "string"
+          },
+          "build_date": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "changelog_url": {
+            "format": "uri",
             "type": "string"
           },
           "engine_mode": {
             "type": "string"
           },
           "engine_semantic_version": {
+            "type": "string"
+          },
+          "git_commit": {
             "type": "string"
           },
           "gravitational_deflection": {
@@ -524,8 +547,33 @@
           "kernel_hash": {
             "type": "string"
           },
+          "kernel_id": {
+            "example": "de440",
+            "type": "string"
+          },
           "kernel_load_seconds": {
             "type": "number"
+          },
+          "kernel_source": {
+            "example": "JPL DE440",
+            "type": "string"
+          },
+          "node_policy_id": {
+            "type": "string"
+          },
+          "supported_bodies": {
+            "items": {
+              "$ref": "#/components/schemas/CelestialBody"
+            },
+            "type": "array"
+          },
+          "tolerance_arcsec": {
+            "example": 0.00036,
+            "type": "number"
+          },
+          "validation_baseline": {
+            "example": "JPL Horizons",
+            "type": "string"
           },
           "version": {
             "type": "string"
@@ -539,7 +587,19 @@
           "house_system",
           "gravitational_deflection",
           "kernel_hash",
-          "kernel_load_seconds"
+          "kernel_load_seconds",
+          "kernel_id",
+          "kernel_source",
+          "ayanamsa_id",
+          "ayanamsa_algorithm",
+          "ayanamsa_version",
+          "git_commit",
+          "build_date",
+          "tolerance_arcsec",
+          "validation_baseline",
+          "changelog_url",
+          "node_policy_id",
+          "supported_bodies"
         ],
         "type": "object"
       },
@@ -904,7 +964,7 @@
   },
   "info": {
     "title": "Daanyam Astro Engine API",
-    "version": "0.17.0"
+    "version": "0.18.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/dist/openapi.json.sha256
+++ b/dist/openapi.json.sha256
@@ -1,0 +1,1 @@
+fd229d596e3d0ab9e74d9b68180d96da6d1f64d66a47daddb8883bf2611a0e67  dist/openapi.json

--- a/docs/adr/0004-outer-planets-deferred.md
+++ b/docs/adr/0004-outer-planets-deferred.md
@@ -1,0 +1,29 @@
+# ADR 0004: Uranus, Neptune, and Pluto deferred from DE440 motion surface
+
+## Status
+
+Accepted (Sprint 5, Phase 1)
+
+## Context
+
+Horizons-vetted station-window regressions require stable `CelestialBody` / kernel targets, API body enums, and motion pipelines. The engine today supports Sun–Saturn plus Rahu/Ketu only (`crates/astro-core/src/contracts.rs`). Sprint 5 delivered Jupiter and Saturn station fixtures under `tests/golden/horizons_stations/` and CI job `horizons-regression`.
+
+## Decision
+
+Defer Uranus, Neptune, and Pluto until a dedicated epic adds:
+
+1. `CelestialBody` and `KernelTarget` entries in `de440.rs`
+2. OpenAPI / positions body enums and chart graha lists (additive only)
+3. Thirty Horizons station fixtures (3 bodies × 10 instants, 2020–2030)
+
+Track B is not in Sprint 5 scope.
+
+## Consequences
+
+- Issue [outer-planet-station-regression.md](../issues/outer-planet-station-regression.md) remains open for the outer three bodies only.
+- Jupiter/Saturn station coverage is closed for supported grahas.
+- No HTTP JSON schema version bump required for deferral.
+
+## Target
+
+Phase 2 epic: outer-planet kernel + Horizons station suite (estimate: one sprint after Phase 1 checklist).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ Architectural decision records capture cross-cutting decisions for the engine an
 | --- | --- | --- | --- |
 | 0002 | API Schema Versioning | Accepted | [docs/adr/0002-api-schema-versioning.md](/Users/sanjeet/Documents/Playground/docs/adr/0002-api-schema-versioning.md) |
 | 0003 | Topocentric Observer Policy | Proposed | [docs/adr/0003-topocentric-observer-policy.md](/Users/sanjeet/Documents/Playground/docs/adr/0003-topocentric-observer-policy.md) |
+| 0004 | Outer Planets Deferred | Accepted | [docs/adr/0004-outer-planets-deferred.md](0004-outer-planets-deferred.md) |
 
 ## Status vocabulary
 

--- a/docs/day1_execution_artifact_apr18.md
+++ b/docs/day1_execution_artifact_apr18.md
@@ -1,0 +1,373 @@
+# Day 1 Execution Artifact
+
+Date: April 18, 2026
+Sprint: Astro Engine Day 1
+Scope: `daanyam-webapp` to `daanyam-astroengine` integration contract, plus sell-API MVP decisions
+
+## 1. Route Mapping
+
+This table is source-backed from `daanyam-webapp` and `astro-api` as they exist on April 18, 2026.
+
+| Webapp surface | Current webapp route/file | Astro-engine endpoint | Mapping status | Notes |
+| --- | --- | --- | --- | --- |
+| Dasha calculator page | `/dasha-calculator` -> `POST /api/dasha` | `POST /dasha` | Day 2 | Primary user-facing dasha flow. |
+| Kundli explainer page | `/kundli-explainer` -> `POST /api/dasha` + `POST /api/planet-positions` | `POST /dasha` + `POST /positions/sidereal` | Day 2-3 | `lagna` is optional in current webapp response, so page can survive without it initially. |
+| Compatibility page | `/compatibility` -> `POST /api/dasha` for saved user profile only | `POST /dasha` | Day 2 | Indirect use only; the main compatibility scoring route is not engine-backed yet. |
+| Profile page | `/profile` -> `POST /api/dasha` | `POST /dasha` | Day 2 | Same adapter as `/api/dasha`. |
+| Dasha job route | `POST /api/dasha/job` | `POST /dasha` | Day 2 | Background route should reuse the same adapter as `/api/dasha`. |
+| Planet positions route | `POST /api/planet-positions` | `POST /positions/sidereal` | Day 3 | Main consumer today is `/kundli-explainer`. |
+| Kundli explainer API | `POST /api/kundli-explain` | none directly | No direct engine call | Depends on `/api/dasha` and `/api/planet-positions`, not on a separate engine endpoint. |
+| Kundli matching | `POST /api/kundli-matching` | none this sprint | Deferred | Today it computes locally via `computeAshtakoota()`. Future engine path would be two birth-chart calls, but no direct mapping is required for Days 2-7. |
+| Compatibility narrative | `POST /api/compatibility` | none | Out of scope | LLM-only narrative route. It consumes already-computed compatibility fields. |
+| Panchang page | `/panchang` -> local `getCachedPanchang()` | no complete current endpoint | Deferred/partial | Current engine has no `/panchanga` route. `POST /positions/sidereal` can only cover graha positions, not tithi/yoga/karana/vara. |
+| Muhurat page | `/muhurat` -> local `findMuhurats()` + local dasha calc | no complete current endpoint | Deferred/partial | Current engine cannot yet replace muhurat search. It can later help with birth dasha personalization, but not full muhurta scoring. |
+| Vaishno Devi muhurat API | `POST /api/vaishno-devi/muhurat` | no complete current endpoint | Deferred/partial | Depends on local panchang plus dasha today. |
+| Vaishno Devi panchang API | `GET /api/vaishno-devi/panchang` | no complete current endpoint | Deferred | Blocked on a dedicated engine panchanga route. |
+
+### Exact route decisions for this sprint
+
+1. `POST /api/dasha` maps to `POST /dasha`.
+2. `POST /api/planet-positions` maps to `POST /positions/sidereal`.
+3. No webapp route maps directly to `POST /chart/sidereal` today, but we should introduce one in Day 3 for chart-first consumers instead of overloading `/api/planet-positions`.
+4. Panchang and muhurat stay on existing local code during this sprint, except for optional dasha personalization reuse.
+
+### Recommended new internal route for Day 3
+
+Add a webapp server route such as `POST /api/chart-sidereal` that maps 1:1 to `POST /chart/sidereal`.
+
+Reason:
+
+- `POST /chart/sidereal` returns `lagna`, `houses`, `grahas`, `d9_rashi`, and compact chart `dasha`.
+- Those fields do not fit cleanly into the current `/api/planet-positions` contract.
+- A dedicated chart route keeps the Day 3 integration explicit and avoids hidden shape creep.
+
+## 2. Request and Response Differences We Must Adapt
+
+## 2.1 `POST /api/dasha` -> `POST /dasha`
+
+### Webapp request today
+
+```json
+{
+  "name": "optional",
+  "date": "1990-05-15",
+  "time": "14:30",
+  "timezone": "Asia/Kolkata",
+  "latitude": 28.6139,
+  "longitude": 77.2090,
+  "engine": "optional"
+}
+```
+
+### Astro-engine request
+
+```json
+{
+  "moon_sidereal_longitude_deg": 199.46019874126517,
+  "birth_time_utc_rfc3339": "1990-05-15T09:00:00Z"
+}
+```
+
+### Required request adaptation
+
+1. Normalize webapp birth input to UTC.
+2. Derive `moon_sidereal_longitude_deg` before the engine call.
+3. Send the engine the reduced dasha request, not the raw birth payload.
+
+### Important constraint
+
+The current webapp `tryAstroApiDasha()` implementation assumes the engine returns a `DashaResult`-shaped payload. That is false.
+
+### Webapp response today
+
+```json
+{
+  "ok": true,
+  "name": "optional",
+  "data": {
+    "input": {},
+    "timeline": {
+      "mahadashas": [],
+      "antardashas": [],
+      "pratyantars": []
+    },
+    "current": {
+      "maha": {},
+      "antar": {},
+      "pratyantar": {}
+    },
+    "meta": {
+      "moonSiderealLongitude": 0,
+      "nakshatraName": "Swati",
+      "rashiName": "Tula"
+    },
+    "summary": "..."
+  },
+  "engineUsed": "inhouse",
+  "engineMode": "swiss",
+  "fallbackReason": null,
+  "warnings": []
+}
+```
+
+### Astro-engine response
+
+```json
+{
+  "data": {
+    "dasha": {
+      "maha": { "lord": "rahu", "start": "...", "end": "..." },
+      "antar": { "lord": "jupiter", "start": "...", "end": "..." },
+      "pratyantar": { "lord": "saturn", "start": "...", "end": "..." }
+    }
+  },
+  "metadata": {
+    "engine_semantic_version": "0.17.0",
+    "ayanamsa_used": "lahiri"
+  }
+}
+```
+
+### Required response adaptation
+
+1. Convert engine `lord` values to webapp `planet` enum values.
+2. Preserve the existing webapp `DashaApiResponseSchema` for this sprint.
+3. Reconstruct missing `timeline`, `meta`, `input`, and `summary` in the webapp adapter.
+4. Inject webapp transport metadata: `engineUsed`, `engineMode`, `fallbackReason`, `warnings`.
+
+### Decision
+
+For Days 2-7, the webapp contract stays stable. We adapt engine output into the existing `DashaResult` shape instead of rewriting all dasha consumers.
+
+## 2.2 `POST /api/planet-positions` -> `POST /positions/sidereal`
+
+### Webapp request today
+
+```json
+{
+  "date": "1990-05-15",
+  "time": "14:30",
+  "timezone": "Asia/Kolkata",
+  "latitude": 28.6139,
+  "longitude": 77.2090
+}
+```
+
+### Astro-engine request
+
+```json
+{
+  "datetime": {
+    "kind": "utc",
+    "utc": "1990-05-15T09:00:00Z"
+  },
+  "geo": {
+    "latitude_deg": 28.6139,
+    "longitude_deg": 77.2090,
+    "elevation_m": 0
+  },
+  "ayanamsa": "lahiri",
+  "bodies": ["sun", "moon", "mars", "mercury", "jupiter", "venus", "saturn", "rahu", "ketu"],
+  "gravitational_deflection": false,
+  "compact": false,
+  "projection": "sidereal_only"
+}
+```
+
+### Webapp response today
+
+```json
+{
+  "ok": true,
+  "planets": [
+    {
+      "planet": "Moon",
+      "rashi": "Libra",
+      "rashiSanskrit": "Tula",
+      "isRetrograde": false
+    }
+  ],
+  "lagna": "Sagittarius",
+  "engineUsed": "inhouse",
+  "engineMode": "swiss",
+  "fallbackReason": null
+}
+```
+
+### Astro-engine response
+
+```json
+{
+  "data": {
+    "positions": [
+      {
+        "body": "moon",
+        "sidereal_longitude_deg": 199.46019874126517,
+        "longitude_speed_deg_per_day": 13.176358,
+        "retrograde": false
+      }
+    ]
+  },
+  "metadata": {
+    "engine_semantic_version": "0.17.0",
+    "ayanamsa_used": "lahiri"
+  }
+}
+```
+
+### Required response adaptation
+
+1. Map engine `body` to title-case `planet`.
+2. Derive English and Sanskrit rashi names from `sidereal_longitude_deg`.
+3. Map `retrograde` to `isRetrograde`.
+4. Add webapp transport fields: `ok`, `engineUsed`, `engineMode`, `fallbackReason`.
+5. Set `lagna` to `undefined` in the first pass, or switch this route to chart-backed mode later.
+
+### Important constraint
+
+`POST /positions/sidereal` does not return `lagna`. That is acceptable for `/kundli-explainer` because `lagna` is already optional there, but it means `/api/planet-positions` cannot remain a full drop-in replacement for the current in-house output if some future caller requires ascendant data.
+
+## 2.3 `POST /chart/sidereal`
+
+### What it gives us
+
+- `lagna`
+- `houses`
+- `grahas`
+- `moon_sidereal_longitude_deg`
+- `moon_nakshatra`
+- `moon_pada`
+- chart summary blocks
+- compact current dasha
+- `d9_rashi`
+
+### What it does not give us
+
+- full Vimshottari timeline arrays
+- current webapp `DashaResult` envelope
+- full panchang limbs
+
+### Sprint use
+
+Use this route for Day 3 chart-first work, not for Day 2 dasha migration.
+
+## 2.4 Cross-cutting transport differences
+
+1. Astro-engine always returns a `{ data, metadata }` envelope.
+2. Webapp public routes currently return route-specific envelopes such as `{ ok, data, engineUsed, ... }`.
+3. Astro-engine uses lowercase snake_case enum values such as `moon`, `rahu`, `ketu`, `tula`, `swati`.
+4. Webapp consumers often expect title-case planet labels and English/Sanskrit display strings.
+5. Astro-engine currently supports `ayanamsa = "lahiri"` only.
+6. Astro-engine geolocation is parsed but still geocentric in Phase 1. We should not claim topocentric accuracy in webapp copy yet.
+
+## 2.5 Proxy behavior we must change
+
+The current webapp helper `tryProxyAstroApiRequest()` is not sufficient for integration because it only forwards raw request bodies and pathnames. That works only when route shapes already match.
+
+It does not work for:
+
+- `/api/dasha`, because engine request and response shapes differ.
+- `/api/planet-positions`, because the engine route is `/positions/sidereal`, not `/planet-positions`, and the response shape differs.
+
+Decision:
+
+Use a typed `astroEngineClient.ts` plus per-route adapters, not a blind proxy, for Day 2 and Day 3.
+
+## 3. Sprint Decisions
+
+These are the Day 1 decisions for the Apr 18-24 sprint.
+
+### Auth
+
+- Engine auth will be header-based API key auth using `x-api-key`.
+- Public unauthenticated routes remain `GET /health` and `GET /openapi.json`.
+- All mutating or billable engine routes stay protected: `/dasha`, `/positions`, `/positions/sidereal`, `/chart/sidereal`.
+- We will not depend on Cloud Run IAM for app-to-engine auth in this sprint because the webapp needs a simple server-side secret path that also works in local and staging.
+
+### Key storage
+
+- Sprint MVP: engine reads allowed keys from env var `VALID_API_KEYS`.
+- Webapp stores its internal service key in server env var `ASTRO_ENGINE_SERVICE_KEY`.
+- Webapp must inject `x-api-key` on every engine request from server code only.
+- Hashed DB-backed key storage is deferred until after the sprint.
+
+### Rate limiting
+
+- Enforce per-key RPM in the engine middleware.
+- Internal webapp service key gets a high limit: `1000 RPM`.
+- External customer keys get `60 RPM` default for MVP.
+- Daily quota is measured in logs during this sprint but not enforced yet.
+
+Reason:
+
+- RPM enforcement is enough to protect the service this week.
+- Daily quota enforcement requires persistent storage and customer state we are not building in Days 2-7.
+
+### Billing scope
+
+- No automated billing integration in this sprint.
+- This sprint includes only key auth, usage logging, hosted docs, and a request-access flow.
+- Commercial rollout is manual pilot billing, not self-serve usage billing.
+- Packaging decision: flat monthly pilot tiers, not per-request billing yet.
+
+Reason:
+
+- We need real usage data before locking a per-request pricing model.
+- Tiered pilots let us sell immediately after the sprint without adding Stripe/Razorpay complexity.
+
+## 4. Prioritized Task Board for Days 2-7
+
+## P0
+
+| Day | Task | Depends on | Definition of done |
+| --- | --- | --- | --- |
+| Day 2 | Build `astroEngineClient.ts` with typed request builders for `/dasha`, `/positions/sidereal`, `/chart/sidereal` | Day 1 contract | Webapp has one server-only client with base URL, timeout, request-id propagation, `x-api-key` support, and normalized engine errors. |
+| Day 2 | Implement `/api/dasha` adapter on top of engine `/dasha` | `astroEngineClient.ts` | `/api/dasha` returns the current `DashaApiResponseSchema` when `USE_ASTRO_API_V2=true`, with no consumer changes required. |
+| Day 2 | Reuse the same adapter in `/api/dasha/job` | `/api/dasha` adapter | Job route stores a payload identical to the interactive dasha route payload. |
+| Day 3 | Implement `/api/planet-positions` adapter on top of `/positions/sidereal` | `astroEngineClient.ts` | `/api/planet-positions` returns the existing `PlanetPositionsResponse` contract using astro-engine data. |
+| Day 3 | Introduce a new webapp chart route backed by `/chart/sidereal` | `astroEngineClient.ts` | There is one server route that exposes `lagna`, `houses`, `grahas`, and compact chart dasha without overloading `/api/planet-positions`. |
+| Day 4 | Add engine auth middleware and service key injection from webapp | Day 2-3 engine client | Engine returns `401` for missing/invalid keys, and webapp requests succeed end to end in local and staging. |
+
+## P1
+
+| Day | Task | Depends on | Definition of done |
+| --- | --- | --- | --- |
+| Day 5 | Add per-key rate limiting middleware | Engine auth middleware | Internal service key stays under high RPM, external keys are limited, and `429` includes `Retry-After`. |
+| Day 5 | Add structured usage logs by key prefix and endpoint | Engine auth middleware | Every protected request emits endpoint, status, latency, and key-prefix usage data into logs. |
+| Day 6 | Serve hosted docs at `/docs` and publish API auth scheme in OpenAPI | Engine auth middleware | `/docs` renders working Redoc against the live OpenAPI spec and documents `x-api-key`. |
+| Day 6 | Publish `/api-access` page in webapp | Pricing decision | Page is live with endpoints overview, pilot pricing copy, and request-access flow. |
+
+## P2
+
+| Day | Task | Depends on | Definition of done |
+| --- | --- | --- | --- |
+| Day 7 | End-to-end regression pack | Days 2-6 | Tests cover dasha, planet positions, chart route, `401`, and `429` against a deployed engine. |
+| Day 7 | Monitoring and alerting setup | Usage logs in place | Dashboard shows request rate, latency, error rate, and Cloud Run health. |
+| Day 7 | Fallback verification | Day 2-3 adapters | With `USE_ASTRO_API_V2=false`, existing webapp fallback paths still work. |
+| Day 7 | Deploy and env doc updates | Auth and rate-limit env settled | Both repos document required vars, staging is green, and production rollout is unblocked. |
+
+## Dependency order
+
+1. Typed client and adapters.
+2. Dasha migration.
+3. Planet positions migration.
+4. Chart route introduction.
+5. Auth.
+6. Rate limits plus usage logs.
+7. Docs and access page.
+8. E2E verification and monitoring.
+
+## 5. Explicit Non-Goals for This Sprint
+
+- No engine-backed full panchang replacement.
+- No engine-backed muhurat search replacement.
+- No DB-backed API key issuance or revocation UI.
+- No Stripe or Razorpay billing integration.
+- No topocentric accuracy claims in product copy.
+
+## 6. Immediate Implementation Guidance for Day 2
+
+1. Do not use `tryProxyAstroApiRequest()` for dasha or planet positions.
+2. Preserve the current webapp response schemas and adapt engine output into them.
+3. Add `ASTRO_ENGINE_SERVICE_KEY` support to webapp server request headers from the start, even if engine auth lands on Day 4.
+4. Keep `USE_ASTRO_API_V2` as the rollback switch for all migrated routes.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -24,6 +24,7 @@ Optional observability:
 | Variable | Purpose |
 | --- | --- |
 | `RUST_LOG` | Rust tracing/log filter (e.g. `info`, `warn`). |
+| `METRICS_TOKEN` | Bearer secret for `GET /metrics` (Prometheus scrape). When unset, `/metrics` returns 503. |
 | `GOOGLE_CLOUD_PROJECT`, `GCP_PROJECT`, or `GCLOUD_PROJECT` | When set, `x-cloud-trace-context` is mapped to Cloud Logging trace fields in stderr JSON logs. |
 
 Configurable startup:
@@ -82,7 +83,8 @@ Each request emits one structured JSON line on stderr with `message` set to `api
 - Kubernetes samples:
   - [deploy/k8s/deployment.yaml](../deploy/k8s/deployment.yaml)
   - [deploy/k8s/service.yaml](../deploy/k8s/service.yaml)
-- Cloud Run manifest: [deploy/cloudrun/service.yaml](../deploy/cloudrun/service.yaml)
+- Cloud Run manifest (**canonical** for CI/CD): [deploy/cloudrun/service.yaml](../deploy/cloudrun/service.yaml)
+- Alternate Cloud Run template (hand deploy / `astro-engine` naming): [deploy/cloud_run.yaml](../deploy/cloud_run.yaml) — same `minScale: "1"` policy; not used by `deploy.yml` / `cloudbuild.yaml`
 - GitHub Actions:
   - [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)
   - [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml)

--- a/docs/engine/yogas-roadmap.md
+++ b/docs/engine/yogas-roadmap.md
@@ -1,0 +1,93 @@
+# Yoga Detection — Phase 4 Roadmap
+
+Engine v0.18+ ships classical yoga detection. The Patrika and Explainer both light up the yogas band only when this work lands.
+
+Current state (May 2026):
+- Scaffold landed: `crates/astro-vedic/src/yogas/` with the `Yoga` trait, `YogaChartFacts` data shape, registry, and 2 example detectors (Gajakesari, Chandra-Mangal).
+- Inventory below is priority-ordered. Each yoga adds one file under `crates/astro-vedic/src/yogas/`, one entry in `registry::all_yoga_keys()` + `registry::detect_yogas()`, and one golden test fixture.
+- Target: 30 yogas across 3 weeks (~10 per week, 2–4 hours each including the golden test).
+
+## Definition of done for a single yoga
+
+1. New file `yogas/<snake_name>.rs` with a `pub struct <PascalName>;` implementing the `Yoga` trait.
+2. Detector unit tests (positive, negative, missing-data) in the same file.
+3. Registered in `registry.rs` (both `all_yoga_keys` and `detect_yogas`).
+4. Golden test in `crates/astro-vedic/tests/golden/yoga_<chart>.json` with a hand-verified birth chart from one of the well-known charts (Buddha, Vivekananda, Gandhi, Adi Shankaracharya — public-domain references).
+5. Daanyam-voice line passes the editor's read: no prediction, no fear, Sanskrit nouns + everyday English verbs.
+
+## Tier 1 — Highly cited, must-ship (10 yogas)
+
+These are the names Indian seekers actually search for. Detection failure here is the most visible quality gap.
+
+1. **Gajakesari** — Moon + Jupiter mutual kendra. *(Scaffolded.)*
+2. **Chandra-Mangal** — Moon + Mars same rashi. *(Scaffolded.)*
+3. **Budhaditya** — Sun + Mercury same rashi, Mercury not combust. Sun must be applying.
+4. **Neecha Bhanga Raja Yoga** — A debilitated planet's dispositor in kendra/trikona from lagna or moon, OR debilitated planet exalted in navamsha.
+5. **Vipreet Raja Yoga** — Lords of dusthana houses (6, 8, 12) in mutual exchange or aspecting each other.
+6. **Dhana Yoga** — Lords of dhana houses (2, 5, 9, 11) in kendra/trikona to lagna with mutual aspect or exchange.
+7. **Raja Yoga (kendra-trikona)** — Lords of trikona (1, 5, 9) and kendra (1, 4, 7, 10) in mutual exchange or conjunction.
+8. **Kemadruma Yoga** — Moon with no graha in adjacent rashis (12th, 2nd from moon) and no graha in 2nd from moon, and Moon not in kendra from lagna. Treat as soft caution, not curse.
+9. **Sunapha Yoga** — Graha (other than Sun) in 2nd from Moon.
+10. **Anapha Yoga** — Graha (other than Sun) in 12th from Moon.
+
+## Tier 2 — Pancha Mahapurusha (5 yogas)
+
+The five "great-person" yogas. These are well-known to seekers and have crisp, easily testable rules.
+
+11. **Ruchaka** — Mars in own (Mesha, Vrischika) or exalted (Makara) sign, in a kendra from lagna.
+12. **Bhadra** — Mercury in own (Mithuna, Kanya) or exalted sign, in a kendra.
+13. **Hamsa** — Jupiter in own (Dhanu, Meena) or exalted (Karka) sign, in a kendra.
+14. **Malavya** — Venus in own (Vrischika, Tula) or exalted (Meena) sign, in a kendra.
+15. **Shasha** — Saturn in own (Makara, Kumbha) or exalted (Tula) sign, in a kendra.
+
+## Tier 3 — Common second-order yogas (10 yogas)
+
+Less canonical but high-impact when present.
+
+16. **Vipareeta Raja Yoga · Vimala** — Lord of 12 in 6/8/12.
+17. **Vipareeta Raja Yoga · Sarala** — Lord of 8 in 6/8/12.
+18. **Vipareeta Raja Yoga · Harsha** — Lord of 6 in 6/8/12.
+19. **Akhanda Samrajya Yoga** — Lord of 2/9/11 in kendra from lagna with Jupiter in lagna, 2nd, 5th, 9th, or 11th.
+20. **Lakshmi Yoga** — Lord of 9 in own house or exalted, with strong lagna lord, Jupiter or Venus in kendra.
+21. **Saraswati Yoga** — Mercury, Jupiter, Venus together or in mutual kendra, with Jupiter in own/exalted in kendra/trikona.
+22. **Adhi Yoga** — Benefics (Mercury, Jupiter, Venus) in 6, 7, 8 from Moon.
+23. **Maha Bhagya Yoga** — Day birth: Sun, Moon, lagna in odd signs. Night birth: in even signs.
+24. **Parijatha Yoga** — Lagna lord's dispositor's dispositor's dispositor in kendra (4-step exalted chain).
+25. **Veshi/Vasi/Ubhayachari** — graha (not Moon) in 2nd / 12th / both sides of Sun (treat as 3 mini-detectors).
+
+## Tier 4 — Less-cited but classically important (5 yogas)
+
+These show up in serious readings; lower SEO demand, higher prestige.
+
+26. **Sakata Yoga** — Moon in 6, 8, 12 from Jupiter. Soft framing.
+27. **Daridra Yoga** — Lord of 11 in 6/8/12. Soft framing.
+28. **Bhaskara Yoga** — Mercury in 2nd from Sun, Moon in 11th from Mercury, Jupiter in 5th or 9th from Moon.
+29. **Kahala Yoga** — Lords of 4 and 9 in mutual kendra or exchange, with strong lagna lord.
+30. **Pushkala Yoga** — Lord of Moon-sign with Moon's dispositor in kendra, strongly aspected by lagna lord.
+
+## Charts to use for golden tests
+
+Use public-domain birth charts to seed the golden tests. The list below is curated for breadth (different lagnas, different formations).
+
+| Chart | Birth | Use for |
+|---|---|---|
+| Mahatma Gandhi | 1869-10-02, 07:08, Porbandar | Gajakesari (Moon-Jupiter mutual kendra), Saturn debilitation cases |
+| Sri Ramakrishna | 1836-02-18, ~05:30, Kamarpukur | Raja Yoga, Dhana Yoga, Hamsa |
+| Adi Shankaracharya | (traditional 788 CE) | Jupiter dominance, Sannyasa yogas |
+| APJ Abdul Kalam | 1931-10-15, 01:00, Rameshwaram | Budhaditya, Akhanda Samrajya |
+| Sachin Tendulkar | 1973-04-24, 17:15, Mumbai | Ruchaka, neecha bhanga of Saturn |
+
+For each detector, pick the chart that has the yoga textbook-clean AND one chart that does NOT (negative test). Add both as JSON fixtures.
+
+## Why this ordering
+
+- Tier 1 covers the names that show up in seeker search queries. Detection failure here is the biggest quality gap.
+- Tier 2 (Pancha Mahapurusha) ships fast — simple rules, easily testable.
+- Tier 3 fills out the Patrika's "yogas band" without spending the budget on edge cases.
+- Tier 4 ships if time remains; deferring these to a Phase 4.1 release is fine.
+
+## Don't ship in v0.18
+
+- Astakavarga-derived yogas. They need a separate Phase that adds Bhinnashtakavarga first.
+- Combinations requiring D-30 (Trimshamsha) — wait for Phase 2 vargas to land.
+- Combinations requiring Mantreshwara's Phaladeepika definitions where Parashara is ambiguous. Pick Parashara unless there's a single accepted reading.

--- a/docs/env.production.example
+++ b/docs/env.production.example
@@ -15,6 +15,9 @@ ASTRO_EPHE_CACHE_DIR=/tmp/ephe
 
 RUST_LOG=warn
 
+# Required for Prometheus / launch-week scrape of GET /metrics (Authorization: Bearer).
+METRICS_TOKEN=replace-with-long-random-metrics-token
+
 # Optional: maps x-cloud-trace-context to logging.googleapis.com/* fields in stderr JSON.
 # GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 

--- a/docs/issues/outer-planet-station-regression.md
+++ b/docs/issues/outer-planet-station-regression.md
@@ -1,0 +1,30 @@
+# Issue: Outer planet station-window regression (Uranus, Neptune, Pluto)
+
+**Status:** Jupiter and Saturn **done** (Sprint 5); Uranus / Neptune / Pluto **blocked** — see [ADR 0004](../adr/0004-outer-planets-deferred.md)
+
+**Source of truth:** [JPL Horizons](https://ssd.jpl.nasa.gov/horizons/)
+
+## Completed (supported grahas)
+
+| Body | Fixtures | Test | CI |
+|------|----------|------|-----|
+| Jupiter | `tests/golden/horizons_stations/jupiter.json` (5 retrograde entry + 5 direct, 2020–2030) | `crates/astro-core/tests/outer_planet_stations.rs` | `.github/workflows/horizons.yml` |
+| Saturn | `tests/golden/horizons_stations/saturn.json` (5 + 5, 2020–2030) | same | same |
+
+Speed-sign contract: `retrograde == true` iff `longitude_speed_deg_per_day < -1e-12` (`astro_core::motion`). Station windows assert sign flip within ±0.5 day of curated UTC.
+
+## Remaining (not in engine)
+
+For each of **Uranus**, **Neptune**, **Pluto** (not in `CelestialBody` today):
+
+- 5 retrograde-entry station instants (2020–2030)
+- 5 direct (end retrograde) station instants (2020–2030)
+
+Each instant should be validated against Horizons apparent geocentric ecliptic longitude speed crossing zero within a ±0.5 day window.
+
+**Blocked on:** [ADR 0004](../adr/0004-outer-planets-deferred.md) — kernel targets, API enums, 30 fixtures.
+
+## Acceptance (outer three only)
+
+- 30 assertions (3 planets × 10 instants) on DE440 when kernel is available
+- No change to public HTTP JSON schemas for chart/positions endpoints

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -2,12 +2,15 @@
 
 This Phase 1 slice keeps monitoring setup explicit and reproducible for the Cloud Run production service.
 
+**Related runbooks:** [observability.md](runbooks/observability.md) (logs, BQ, SLO), [oncall.md](runbooks/oncall.md) (paging, triage, rollback), [monitoring-console-steps.md](runbooks/monitoring-console-steps.md) (manual GCP steps).
+
 ## What this covers
 
-- public uptime check against `GET /health`
-- alert policy for uptime failure
+- multi-region uptime check against `GET /health` (60s period)
+- alert policy for uptime failure (2 consecutive failures)
 - alert policy for Cloud Run 5xx count
 - alert policy for Cloud Run p95 latency
+- synthetic chart transaction monitor (script + CI golden test)
 - post-deploy verification steps
 
 The repo already emits structured request logs with `request_id`, `body_hash`, and `latency_ms`. The monitoring setup here uses built-in Cloud Run metrics first, then relies on logs for incident triage.
@@ -30,12 +33,32 @@ gcloud beta monitoring channels list --project "$PROJECT_ID"
 
 These defaults are intentionally conservative starter values for first production rollout:
 
-- uptime check every `1` minute against `/health`
-- uptime failure alert wired to the created uptime check
-- 5xx count alert when more than `5` responses occur in `5` minutes across the service
-- p95 latency alert when p95 exceeds `1500 ms` over a `10` minute window
+| Policy display name (default) | Condition |
+| --- | --- |
+| `<service> health (multi-region)` | `GET /health` every **60s** from `asia-southeast1`, `usa-iowa`, `europe-west1` |
+| `<service> uptime failure` | Uptime check failed **2** consecutive evaluation periods |
+| `<service> 5xx count` | More than **5** `5xx` responses in **5** minutes |
+| `<service> p95 latency` | p95 &gt; **1500 ms** over **10** minutes |
 
 Tune them after a few days of real traffic.
+
+### Multi-region uptime
+
+Cloud Run serves from **asia-south1**; synthetic probes use the nearest supported Monitoring regions (see [monitoring-console-steps.md](runbooks/monitoring-console-steps.md)):
+
+- **asia-southeast1** (stand-in for asia-south1)
+- **usa-iowa** (us-central1)
+- **europe-west1**
+
+Override with `UPTIME_REGIONS` when running `setup_monitoring.sh`.
+
+### Synthetic chart monitor
+
+- **Script:** [`scripts/monitoring/synthetic-chart-sidereal.sh`](../scripts/monitoring/synthetic-chart-sidereal.sh) — every **5 min** recommended (Cloud Scheduler or cron).
+- **Fixture:** [`tests/golden/synthetic/delhi-1990-chart.json`](../tests/golden/synthetic/delhi-1990-chart.json)
+- **Expected lagna:** `275.1573701670353°` (±1e-6°), rashi `makara` (DE440)
+- **CI:** `cargo test -p astro-api --test synthetic_chart_golden`
+- **Alerting:** alert on non-zero exit (Scheduler failure notification) or wire a log-based metric; URL uptime checks cannot assert JSON fields.
 
 ## One-command setup
 
@@ -53,7 +76,9 @@ Useful overrides:
 
 - `SERVICE_URL` if you want to derive the host from a specific deployed URL
 - `SERVICE_HOST` if you want to target a custom domain directly
-- `UPTIME_CHECK_PERIOD=5` for a slower check cadence
+- `UPTIME_CHECK_PERIOD=120s` for a slower check cadence
+- `UPTIME_REGIONS=asia-southeast1,usa-iowa,europe-west1`
+- `UPTIME_CONSECUTIVE_FAILURES=2`
 - `ERROR_COUNT_THRESHOLD=10`
 - `LATENCY_THRESHOLD_MS=2000`
 
@@ -62,7 +87,8 @@ What the script does:
 1. resolves the Cloud Run service URL or host
 2. creates or updates an uptime check on `https://<host>/health`
 3. creates or updates these alert policies:
-   - `<service> uptime failure`
+   - `<service> health (multi-region)` uptime check
+   - `<service> uptime failure` (2 consecutive failures)
    - `<service> 5xx count`
    - `<service> p95 latency`
 
@@ -116,7 +142,8 @@ That helper:
 ASTRO_API_BASE_URL="https://your-cloud-run-url" cargo test -p astro-api --test production_contract
 ```
 
-4. confirms the uptime check and alert policies exist
+4. confirms the multi-region uptime check (three probe regions) and alert policies exist
+5. optional: run [`scripts/monitoring/synthetic-chart-sidereal.sh`](../scripts/monitoring/synthetic-chart-sidereal.sh) against staging
 
 ## Incident triage
 

--- a/docs/perf/baseline-w2.md
+++ b/docs/perf/baseline-w2.md
@@ -1,0 +1,50 @@
+# Sprint 2 — Chart sidereal load baseline (W2)
+
+Baseline captured before / during the webapp `USE_ASTRO_API_V2` flag flip. **Do not commit production URLs or API keys.**
+
+## Run metadata
+
+| Field | Value |
+|-------|-------|
+| Date | TBD |
+| Cloud Run URL | `<redacted>` |
+| Tool | `oha` or `vegeta` (via script) |
+| Endpoint | `POST /chart/sidereal` |
+| Scenario | 50 RPS for 5 minutes, rotating birth fixtures |
+| Auth | `x-api-key: $ASTRO_API_KEY` (see [deploy.md](../deploy.md)) |
+
+## How to run
+
+```bash
+export ASTRO_API_BASE_URL="https://your-cloud-run-url"
+export ASTRO_API_KEY="your-valid-key"
+./scripts/load/baseline-chart-sidereal.sh
+```
+
+Fixtures rotate:
+
+1. Delhi 1990-05-17 (production contract shape)
+2. Bangalore 2000-01-01 (golden lahiri vector date)
+3. Independence 1947-08-15 (golden vector date)
+4. Bangalore 1995-08-12 (golden vector date)
+
+## Results
+
+| Metric | Value |
+|--------|-------|
+| p50 latency | TBD |
+| p95 latency | TBD |
+| p99 latency | TBD |
+| Error rate | TBD |
+| 401 responses | TBD (should be 0 with valid key) |
+| 429 responses | TBD (note if `RATE_LIMIT_RPM` is low) |
+
+## Targets
+
+- **Steady-state goal:** p95 &lt; **200 ms** on `POST /chart/sidereal` (see [WEEK1_PUBLIC_LAUNCH.md](../../WEEK1_PUBLIC_LAUNCH.md)).
+- **Launch guardrail:** roll back webapp flip if p95 &gt; **800 ms** or error rate &gt; **2%** (see [AstroEngine_Sprint_Prompts.md](../../AstroEngine_Sprint_Prompts.md) Sprint 3).
+
+## Notes
+
+- Run only against production after explicit approval.
+- Compare with Cloud Run console p95 and `astro_request_latency_ms_bucket` from `GET /metrics` (bearer `METRICS_TOKEN`).

--- a/docs/perf/baseline-w4.md
+++ b/docs/perf/baseline-w4.md
@@ -1,0 +1,54 @@
+# Sprint 4 — Chart sidereal load baseline (W4, min-instances=1)
+
+Run **after** production deploy with `min-instances=1` ([reliability-min-instances.md](../runbooks/reliability-min-instances.md)). Same scenario as W2; only the warm-instance era differs.
+
+## Run metadata
+
+| Field | Value |
+|-------|-------|
+| Date | TBD |
+| Cloud Run URL | `<redacted>` |
+| minScale | `1` |
+| Tool | `oha` or `vegeta` (via script) |
+| Endpoint | `POST /chart/sidereal` |
+| Scenario | 50 RPS for 5 minutes, rotating birth fixtures |
+| Auth | `x-api-key: $ASTRO_API_KEY` |
+
+## How to run
+
+```bash
+export ASTRO_API_BASE_URL="https://your-cloud-run-url"
+export ASTRO_API_KEY="your-valid-key"
+./scripts/load/baseline-chart-sidereal.sh
+```
+
+Record results in the table below (same script as [baseline-w2.md](baseline-w2.md)).
+
+## Results
+
+| Metric | Value |
+|--------|-------|
+| p50 latency | TBD |
+| p95 latency | TBD |
+| p99 latency | TBD |
+| Error rate | TBD |
+| 401 responses | TBD |
+| 429 responses | TBD |
+
+## Diff vs W2 (minScale=0 era)
+
+| Metric | W2 (baseline-w2.md) | W4 (this doc) | Δ |
+|--------|---------------------|---------------|---|
+| p50 | TBD | TBD | TBD |
+| p95 | TBD | TBD | TBD |
+| p99 | TBD | TBD | TBD |
+| Error rate | TBD | TBD | TBD |
+
+**Cold-start note:** W2 includes scale-to-zero wake; W4 should show lower p95 tail if min=1 is effective. Paste W2 numbers into this section when [baseline-w2.md](baseline-w2.md) is filled.
+
+## Targets
+
+- Steady-state p95 &lt; **200 ms** on `POST /chart/sidereal`
+- Launch guardrail: roll back webapp flip if p95 &gt; **800 ms** or error rate &gt; **2%**
+
+Compare with `GET /metrics` (`astro_request_latency_ms_bucket`) using bearer `METRICS_TOKEN`.

--- a/docs/perf/cold-start-w2.md
+++ b/docs/perf/cold-start-w2.md
@@ -1,0 +1,30 @@
+# Sprint 2 — Cold-start measurement (W2)
+
+W2 baseline used `minScale: "0"`. Production now targets `minScale: "1"` ([deploy/cloudrun/service.yaml](../../deploy/cloudrun/service.yaml), [reliability-min-instances.md](../runbooks/reliability-min-instances.md)). This document records time-to-first-200 on `/health` after a deploy or scale-to-zero wake (min=0 era).
+
+## Procedure
+
+1. Deploy a new revision **or** wait until the service has scaled to zero (no active instances in Cloud Run metrics).
+2. Resolve the service URL:
+
+```bash
+URL=$(gcloud run services describe astro-engine --region asia-south1 --format='value(status.url)')
+```
+
+3. Measure first successful health check (wall-clock from first request):
+
+```bash
+time curl -sS -o /dev/null -w 'http_code=%{http_code} time_total=%{time_total}s\n' "${URL}/health"
+```
+
+Repeat 3–5 times after separate scale-to-zero events for a spread.
+
+## Sample
+
+| Event | time_total (s) | http_code | Notes |
+|-------|----------------|-----------|-------|
+| TBD | TBD | 200 | Run after scale-to-zero or fresh deploy |
+
+## Recommendation (Sprint 4)
+
+Cold-start latency on the first `/health` after scale-to-zero is user-visible when traffic arrives in bursts. Sprint 4 should set **`min-instances=1`** and re-run the W2 load test into `docs/perf/baseline-w4.md` (see [AstroEngine_Sprint_Prompts.md](../../AstroEngine_Sprint_Prompts.md)). **Do not** enable `min-instances=1` in Sprint 2 — measure first, then justify the cost.

--- a/docs/retros/phase1.md
+++ b/docs/retros/phase1.md
@@ -1,0 +1,41 @@
+# Phase 1 retrospective
+
+**Release:** v0.18.0 · **Branch:** `phase1/release-v0.18.0` · **Close date:** 2026-05
+
+## What worked
+
+- **Golden fixtures** — Horizons regression manifest, synthetic Delhi-1990 chart (`275.1573701670353°`), and station windows gave deterministic CI signal without live JPL calls in every test run.
+- **DE440 kernel path** — `ASTRO_EPHE_PATH` + Cloud Run DE440 backend with coverage gate (2024–2150) kept prod and tests on the same ephemeris source.
+- **Sprint prompts** — `AstroEngine_Sprint_Prompts.md` sequenced observability → reliability → Horizons → release without scope bleed.
+- **Repo split** — `daanyam-astroengine` (compute + API) vs `daanyam-webapp` (UX) let engine ship `/provenance`, metrics, and contracts while webapp iterated on founder funnel.
+
+## What broke / friction
+
+- **Demo vs DE440 lagna** — Local `ASTRO_BACKEND=demo` produced different lagna than DE440-backed prod; confused early chart QA until examples pinned `ASTRO_EPHE_PATH`.
+- **Baseline docs unfilled** — [baseline-w2.md](../perf/baseline-w2.md) and [baseline-w4.md](../perf/baseline-w4.md) still TBD; webapp flip gate lacked numeric p95 evidence.
+- **Outer planets deferred** — Uranus/Neptune/Pluto station regressions parked in [ADR 0004](../adr/0004-outer-planets-deferred.md); Jupiter/Saturn only in Horizons CI.
+- **Version drift** — `ENGINE_SEMANTIC_VERSION` lagged CHANGELOG until v0.18.0 alignment.
+
+## Metrics (fill after load test)
+
+| Metric | Target / note | Source |
+|--------|---------------|--------|
+| p95 `POST /chart/sidereal` | TBD ms | [baseline-w2.md](../perf/baseline-w2.md), `scripts/load/baseline-chart-sidereal.sh` |
+| p95 `POST /dasha` | TBD ms | Same |
+| Error rate (5xx) | TBD % | Cloud Monitoring / BQ `api_usage` |
+| `slo_breach` rate | TBD / day | [observability.md](../runbooks/observability.md), BQ [latency_p95.sql](../runbooks/queries/latency_p95.sql) |
+
+*Placeholder — run W2/W4 load scripts and paste numbers before Phase 2 webapp performance claims.*
+
+## Process improvements for Phase 2
+
+1. **Pin DE440 in all examples** — README, runbooks, and webapp snippets default to `ASTRO_EPHE_PATH` + `ASTRO_BACKEND=de440`; demo called out as non-audit.
+2. **Single PR for version + changelog** — Bump `ENGINE_SEMANTIC_VERSION` and `CHANGELOG.md` in the same commit as any user-visible release.
+3. **Webapp flip gate on baseline-w2** — Block `USE_ASTRO_API_V2` prod flip until p95 row filled in baseline-w2 with date + Cloud Run revision.
+4. **Provenance in CI smoke** — Post-deploy verify curls `/provenance` and asserts `kernel_id=de440` + `engine_semantic_version`.
+5. **Horizons tolerance in manifest** — `/provenance.tolerance_arcsec` documents station-suite (1e-7°) vs general regression (1e-9°) to reduce support confusion.
+
+## Handoff
+
+- **Phase 2 entry:** Sprint 7 in [AstroEngine_Sprint_Prompts.md](../../AstroEngine_Sprint_Prompts.md) (Raman ayanamsa / feature superiority).
+- **Checklist:** [phase1-checklist-evidence.md](../runbooks/phase1-checklist-evidence.md).

--- a/docs/runbooks/launch-week-monitoring.md
+++ b/docs/runbooks/launch-week-monitoring.md
@@ -1,0 +1,67 @@
+# Launch Week Monitoring Runbook
+
+This runbook defines the `/metrics` scrape contract and the minimum launch watch checks for the public beta window.
+
+For request-ID tracing, SLO breach logs, and Cloud Logging → BigQuery setup, see [observability.md](observability.md).
+
+## Scrape Target
+
+- Base URL: Cloud Run public URL for `astro-engine`
+- Path: `/metrics`
+- Method: `GET`
+- Auth: `Authorization: Bearer $METRICS_TOKEN` (set `METRICS_TOKEN` on the Cloud Run service; route is public for API-key middleware but bearer-gated in the handler)
+- Scrape interval: `30s`
+- Scrape timeout: `10s`
+
+Prometheus-style scrape config example:
+
+```yaml
+scrape_configs:
+  - job_name: astro-engine
+    scrape_interval: 30s
+    scrape_timeout: 10s
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials: "${METRICS_TOKEN}"
+    static_configs:
+      - targets:
+          - astro-engine-592048110971.asia-south1.run.app
+```
+
+## What To Watch During Launch
+
+- `RPS`:
+  - Metric: request throughput from Cloud Run request count and/or `astro_requests_total`.
+  - Watch for sudden drops to near-zero during expected traffic windows.
+- `p95 latency`:
+  - Metric: Cloud Run request latency p95 and/or `astro_request_latency_ms_bucket`.
+  - Trigger investigation if p95 is sustained above `1500 ms` for `10m`.
+- `5xx rate`:
+  - Metric: Cloud Run 5xx response class and/or `astro_requests_total` with `status` label `5xx` (numeric status codes are exported per response).
+  - Trigger investigation if 5xx rate exceeds `1%` for `5m` or if absolute 5xx count spikes.
+- `kernel_load_seconds`:
+  - Metric: `astro_kernel_load_seconds` (startup/runtime metadata).
+  - Track for regressions between revisions; unexpected increases can indicate kernel mount or IO regressions.
+
+## Launch-Day Triage
+
+1. Confirm `GET /health` is 200.
+2. Confirm `/metrics` scrape freshness is < 2 minutes old.
+3. If 5xx spikes:
+   - Inspect Cloud Run revision logs by `jsonPayload.request_id` (inbound `X-Request-Id` from the webapp; see [observability.md](observability.md)).
+   - Check if errors are concentrated on authenticated endpoints (`/chart/sidereal`, `/dasha`) versus public endpoints.
+4. If p95 spikes without 5xx growth:
+   - Check concurrent request load versus instance count ceiling.
+   - Check recent revision rollout and cold-start behavior.
+5. If `kernel_load_seconds` regresses after a deploy:
+   - Verify runtime image and kernel asset path are unchanged.
+   - Roll back to last known-good revision if startup degradation is user-visible.
+
+## Recommended Dashboard Panels
+
+- Request rate (1m + 5m views)
+- p50/p95/p99 latency
+- 4xx and 5xx split by path
+- Container instance count and concurrency utilization
+- `astro_kernel_load_seconds` per revision

--- a/docs/runbooks/monitoring-console-steps.md
+++ b/docs/runbooks/monitoring-console-steps.md
@@ -1,0 +1,72 @@
+# Monitoring setup — Console and gcloud
+
+Use when [`setup_monitoring.sh`](../../deploy/cloudrun/setup_monitoring.sh) cannot be run from CI, or to verify resources created by the script.
+
+## Multi-region uptime check (`GET /health`)
+
+**Goal:** HTTPS probe every **60s** from three synthetic regions; alert after **2 consecutive** failures.
+
+| Sprint region | Cloud Monitoring probe id | Notes |
+| --- | --- | --- |
+| asia-south1 (service region) | `asia-southeast1` | Nearest supported probe to Mumbai |
+| us-central1 | `usa-iowa` | Maps to `us-central1` |
+| europe-west1 | `europe-west1` | EU probe |
+
+### Console
+
+1. **Monitoring → Uptime checks → Create**
+2. Target: **URL**, protocol **HTTPS**, path `/health`, host = Cloud Run hostname (no path prefix).
+3. Check frequency: **1 minute** (60s).
+4. Select regions: **asia-southeast1**, **usa-iowa**, **europe-west1** (minimum 3).
+5. Response validation: status class **2xx**.
+6. Display name: `astro-api health (multi-region)` (or `${CLOUD_RUN_SERVICE} health (multi-region)`).
+
+### gcloud
+
+```bash
+export PROJECT_ID="your-gcp-project"
+export SERVICE_HOST="astro-api-xxxxx.asia-south1.run.app"   # no https://
+
+gcloud monitoring uptime create "${SERVICE_NAME:-astro-api} health (multi-region)" \
+  --project="${PROJECT_ID}" \
+  --resource-type=uptime-url \
+  --resource-labels="host=${SERVICE_HOST},project_id=${PROJECT_ID}" \
+  --path=/health \
+  --protocol=https \
+  --request-method=get \
+  --status-classes=2xx \
+  --period=60s \
+  --timeout=10 \
+  --regions=asia-southeast1,usa-iowa,europe-west1 \
+  --validate-ssl=true
+```
+
+### Uptime alert (2 consecutive failures)
+
+1. **Monitoring → Alerting → Create policy**
+2. Condition: metric `monitoring.googleapis.com/uptime_check/check_passed`, filter by uptime check id, threshold **> 1** failed checks over **60s** alignment, trigger **count = 2** (or duration covering two failed periods).
+3. Notification channel: set `NOTIFICATION_CHANNELS` to your PagerDuty/email channel resource name, e.g. `projects/PROJECT/notificationChannels/PAGERDUTY_CHANNEL_ID`.
+4. Display name: `astro-api uptime failure`.
+
+Repo template: [`deploy/cloudrun/alert-policies/uptime_failure.json.tmpl`](../../deploy/cloudrun/alert-policies/uptime_failure.json.tmpl) (rendered by `setup_monitoring.sh`).
+
+## Synthetic chart monitor
+
+Cloud Monitoring URL checks cannot easily assert JSON body fields. Use:
+
+- **Cloud Scheduler** → HTTP target or Cloud Run job running [`scripts/monitoring/synthetic-chart-sidereal.sh`](../../scripts/monitoring/synthetic-chart-sidereal.sh) every 5 minutes; alert on job failure / non-zero exit.
+- Or CI/cron on a trusted runner with `ASTRO_API_BASE_URL` + `ASTRO_API_KEY`.
+
+Golden expected lagna: **275.1573701670353°** (±1e-6°), fixture [`tests/golden/synthetic/delhi-1990-chart.json`](../../tests/golden/synthetic/delhi-1990-chart.json).
+
+## One-command setup
+
+```bash
+PROJECT_ID="..." \
+SERVICE_NAME="astro-api" \
+REGION="asia-south1" \
+NOTIFICATION_CHANNELS="projects/.../notificationChannels/..." \
+bash deploy/cloudrun/setup_monitoring.sh
+```
+
+Post-deploy: `bash deploy/cloudrun/post_deploy_verify.sh`

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -1,0 +1,173 @@
+# Observability Runbook
+
+End-to-end traceability from the webapp through Cloud Run structured logs and BigQuery. For Prometheus scrape and launch-week triage, see [launch-week-monitoring.md](launch-week-monitoring.md).
+
+## Cloud Run service name
+
+| Source | Service name |
+|--------|----------------|
+| Cloud Build default ([`cloudbuild.yaml`](../../cloudbuild.yaml)) | `astro-api` |
+| Alternate manifest ([`deploy/cloud_run.yaml`](../../deploy/cloud_run.yaml)) | `astro-engine` |
+
+Use the name that matches your deployed revision when creating log sinks and filters.
+
+## Request ID contract
+
+1. **Webapp** sends `X-Request-Id: <uuidv4>` (lowercase hyphenated UUID) on every engine HTTP call.
+2. **Engine** accepts inbound `X-Request-Id` (case-insensitive; canonical casing recommended). If absent, it generates a UUID and still echoes it on the response.
+3. **Response** includes the same value in the `x-request-id` header (HTTP header names are case-insensitive).
+4. **Fallback headers:** `X-Correlation-Id` is promoted to `request_id` only when `X-Request-Id` is missing.
+
+### Trace flow
+
+```
+PostHog event (request_id)
+  → Engine call (X-Request-Id header)
+  → Cloud Logging jsonPayload.request_id (api_usage + slo_breach lines)
+  → BigQuery astro_engine_logs.run_googleapis_com_stdout_*
+```
+
+Cloud Logging filter for a single request:
+
+```
+jsonPayload.request_id="<uuid>"
+```
+
+## Structured log events
+
+| message | When |
+|---------|------|
+| `api_usage` | Every request (latency, path, status, engine_version, kernel_hash) |
+| `slo_breach` | Successful (2xx) `POST /chart/sidereal` over 200 ms or `POST /dasha` over 300 ms |
+
+SLO breach filter:
+
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="astro-api"
+jsonPayload.message="slo_breach"
+```
+
+Example `slo_breach` line (stderr JSON):
+
+```json
+{
+  "severity": "WARNING",
+  "message": "slo_breach",
+  "slo_breach": true,
+  "path": "/chart/sidereal",
+  "target_ms": 200,
+  "actual_ms": 245,
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "engine_version": "0.17.2",
+  "kernel_hash": "sha256:…"
+}
+```
+
+## Prometheus metrics
+
+Set `METRICS_TOKEN` on the Cloud Run service and scrape `GET /metrics` with `Authorization: Bearer $METRICS_TOKEN`. See [launch-week-monitoring.md](launch-week-monitoring.md) for scrape config and launch-day panels.
+
+## Cloud Logging → BigQuery export
+
+Export stdout/stderr JSON logs to BigQuery for SQL analysis. No Terraform is required; use `gcloud` or the Console.
+
+### Prerequisites
+
+- GCP project with Cloud Run service deployed (`astro-api` by default)
+- `roles/logging.configWriter` (or equivalent) to create sinks
+- `roles/bigquery.admin` or dataset-level permissions to create the dataset and grant the sink writer account
+
+### 1. Create BigQuery dataset
+
+```bash
+export GCP_PROJECT="your-gcp-project-id"
+export BQ_LOCATION="asia-south1"
+export BQ_DATASET="astro_engine_logs"
+
+gcloud bigquery datasets create "${BQ_DATASET}" \
+  --project="${GCP_PROJECT}" \
+  --location="${BQ_LOCATION}" \
+  --description="Astro engine Cloud Run structured logs"
+```
+
+### 2. Create log sink
+
+```bash
+export CLOUD_RUN_SERVICE="astro-api"
+export SINK_ID="astro-api-logs-to-bq"
+
+gcloud logging sinks create "${SINK_ID}" \
+  "bigquery.googleapis.com/projects/${GCP_PROJECT}/datasets/${BQ_DATASET}" \
+  --project="${GCP_PROJECT}" \
+  --log-filter='resource.type="cloud_run_revision"
+resource.labels.service_name="'"${CLOUD_RUN_SERVICE}"'"' \
+  --use-partitioned-tables
+```
+
+If the sink already exists, update the filter:
+
+```bash
+gcloud logging sinks update "${SINK_ID}" \
+  --project="${GCP_PROJECT}" \
+  --log-filter='resource.type="cloud_run_revision"
+resource.labels.service_name="'"${CLOUD_RUN_SERVICE}"'"'
+```
+
+Note the **writer identity** from sink creation output:
+
+```bash
+gcloud logging sinks describe "${SINK_ID}" \
+  --project="${GCP_PROJECT}" \
+  --format='value(writerIdentity)'
+```
+
+### 3. Grant BigQuery Data Editor to sink writer
+
+```bash
+export SINK_WRITER="serviceAccount:...@gcp-sa-logging.iam.gserviceaccount.com"
+
+gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
+  --member="${SINK_WRITER}" \
+  --role="roles/bigquery.dataEditor"
+```
+
+Or grant at dataset scope:
+
+```bash
+bq add-iam-policy-binding \
+  --member="${SINK_WRITER}" \
+  --role=roles/bigquery.dataEditor \
+  "${GCP_PROJECT}:${BQ_DATASET}"
+```
+
+### 4. Resulting table names
+
+Partitioned daily tables (wildcard in queries):
+
+```
+${GCP_PROJECT}.${BQ_DATASET}.run_googleapis_com_stdout_YYYYMMDD
+```
+
+Example full table prefix for queries:
+
+```
+your-gcp-project-id.astro_engine_logs.run_googleapis_com_stdout_*
+```
+
+Confirm field names (`jsonPayload.path`, `jsonPayload.latency_ms`, etc.) against one exported row after the sink is active.
+
+### Optional idempotent script
+
+```bash
+export GCP_PROJECT="your-gcp-project-id"
+./scripts/gcp/create-log-sink.sh
+```
+
+## BigQuery query templates
+
+- [queries/latency_p95.sql](queries/latency_p95.sql) — p50/p95/p99 per path and `slo_breach` counts (last 24h)
+
+## Perf baselines
+
+Load-test results for `/chart/sidereal` live in [docs/perf/baseline-w2.md](../perf/baseline-w2.md). Fill p50/p95/p99 after running `scripts/load/baseline-chart-sidereal.sh` before Sprint 4 SLO tuning.

--- a/docs/runbooks/oncall.md
+++ b/docs/runbooks/oncall.md
@@ -1,0 +1,62 @@
+# On-call runbook (astro-engine)
+
+Primary service: Cloud Run `astro-api` (asia-south1). Cross-links: [monitoring.md](../monitoring.md), [observability.md](observability.md), [launch-week-monitoring.md](launch-week-monitoring.md), [cold-start-w2.md](../perf/cold-start-w2.md).
+
+## Who gets paged
+
+- **Notification channels:** set `NOTIFICATION_CHANNELS` when running [`setup_monitoring.sh`](../../deploy/cloudrun/setup_monitoring.sh) (comma-separated Monitoring channel resource names).
+- **PagerDuty:** `projects/<PROJECT>/notificationChannels/<PAGERDUTY_CHANNEL_ID>` — replace with your service integration channel id.
+- **PagerDuty service name (placeholder):** `Daanyam Astro Engine Production`
+
+## Severity guide
+
+| Signal | Typical cause | First action |
+| --- | --- | --- |
+| **Uptime fail** (`astro-api health (multi-region)`) | Bad deploy, DNS, SSL, instance crash | `GET /health` from laptop; check latest revision status |
+| **5xx spike** | Kernel mount, OOM, panic | Cloud Logging errors; memory (2Gi limit on alternate manifest) |
+| **p95 regression** | Cold start, load, DE440 IO | Compare [baseline-w4](../perf/baseline-w4.md); check `min-instances`; metrics histogram |
+| **Synthetic chart mismatch** | Ephemeris drift, wrong backend, bad deploy | Run [`synthetic-chart-sidereal.sh`](../../scripts/monitoring/synthetic-chart-sidereal.sh); confirm `ASTRO_BACKEND=de440` |
+| **`slo_breach` log spike** | Latency SLO (>200ms chart, >300ms dasha) | BQ/query templates in [observability.md](observability.md); sample by `request_id` |
+
+## Triage
+
+1. **Cloud Logging** (last 30m):
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_revision" AND resource.labels.service_name="astro-api"' \
+  --project "$PROJECT_ID" \
+  --freshness=30m \
+  --limit=50
+```
+
+2. **Pivot on `request_id`** — present on every `api_usage` line and response header `x-request-id`.
+3. **BigQuery** — log sink and latency SQL: [observability.md](observability.md), [queries/latency_p95.sql](queries/latency_p95.sql).
+4. **Metrics** — `GET /metrics` with `Authorization: Bearer $METRICS_TOKEN` (see [launch-week-monitoring.md](launch-week-monitoring.md)).
+
+## Common failures
+
+| Symptom | Likely cause | Mitigation |
+| --- | --- | --- |
+| Startup crash / 503 on chart | GCS kernel mount fail, missing `de440.bsp` | Verify bucket mount / `ASTRO_EPHE_PATH`; redeploy previous image |
+| OOM / restarts | Memory pressure (2Gi on `deploy/cloud_run.yaml` path) | Raise memory or reduce concurrency; check logs for OOM |
+| 401 storm | Invalid or rotated API key | Client config; `VALID_API_KEYS` on revision |
+| 429 storm | `RATE_LIMIT_RPM` per instance | Raise limit or scale; check abusive key prefix in logs |
+| Synthetic lagna drift | `demo` backend or wrong kernel | Enforce `ASTRO_BACKEND=de440`; compare CI golden test |
+
+## Rollback
+
+1. **Cloud Run:** deploy previous good image digest / revision (GitHub Actions artifact or `gcloud run services update-traffic` to last revision).
+2. **Emergency cost cut:** set `min-instances=0` only if approved — **expect p95 cold-start regression** ([reliability-min-instances.md](reliability-min-instances.md)).
+3. **Webapp:** feature flag rollback is in **daanyam-webapp** — set `USE_ASTRO_API_V2=false` (not implemented in this repo).
+
+## Escalation
+
+- **`kernel_hash` mismatch across replicas** in `api_usage` logs → drain traffic, redeploy single known-good image; verify GCS fuse / kernel version.
+- **Horizons / ephemeris regression** → file under [outer-planet-station-regression.md](../issues/outer-planet-station-regression.md); do not change chart JSON schema under pressure.
+
+## Synthetic reference
+
+- Script: [`scripts/monitoring/synthetic-chart-sidereal.sh`](../../scripts/monitoring/synthetic-chart-sidereal.sh)
+- Expected lagna (DE440, Delhi 1990): **275.1573701670353°** (±1e-6°), rashi `makara`
+- CI: `cargo test -p astro-api --test synthetic_chart_golden`

--- a/docs/runbooks/phase1-checklist-evidence.md
+++ b/docs/runbooks/phase1-checklist-evidence.md
@@ -1,0 +1,46 @@
+# Phase 1 checklist — evidence
+
+Honest status for Phase 1 engineering close. Update checkboxes when evidence is verified in prod or CI.
+
+| Item | Status | Evidence |
+|------|--------|----------|
+| Cloud Run DE440 | ☑ | [deploy/cloudrun/service.yaml](../../deploy/cloudrun/service.yaml), [docs/deploy.md](../deploy.md) |
+| API keys + rate limit | ☑ | `auth_middleware` / `RateLimiter` in [crates/astro-api/src/lib.rs](../../crates/astro-api/src/lib.rs) |
+| `/metrics` + `METRICS_TOKEN` | ☑ | [docs/runbooks/observability.md](observability.md), Sprint 2 metrics route |
+| Request ID + SLO breach | ☑ | [docs/runbooks/observability.md](observability.md) |
+| BQ log sink | ☑ | [scripts/gcp/create-log-sink.sh](../../scripts/gcp/create-log-sink.sh) |
+| min-instances=1 | ☑ | [docs/runbooks/reliability-min-instances.md](reliability-min-instances.md) |
+| Multi-region uptime | ☑ | [docs/monitoring.md](../monitoring.md), `deploy/cloudrun/setup_monitoring.sh` |
+| Synthetic chart monitor | ☑ | [scripts/monitoring/synthetic-chart-sidereal.sh](../../scripts/monitoring/synthetic-chart-sidereal.sh), golden lagna `275.1573701670353°` in [tests/golden/synthetic/delhi-1990-chart.json](../../tests/golden/synthetic/delhi-1990-chart.json) |
+| Horizons station CI | ☑ | [.github/workflows/horizons.yml](../../.github/workflows/horizons.yml), [tests/golden/horizons_stations/](../../tests/golden/horizons_stations/) |
+| Retrograde motion contract | ☑ | [crates/astro-core/src/motion.rs](../../crates/astro-core/src/motion.rs), `retrograde_motion_proptest` |
+| Rich `/provenance` manifest | ☑ | `GET /provenance`, `ENGINE_SEMANTIC_VERSION = 0.18.0` |
+| p95 load baseline (W2) | ☐ TBD | Run `./scripts/load/baseline-chart-sidereal.sh`, paste results into [docs/perf/baseline-w2.md](../perf/baseline-w2.md) |
+| p95 load baseline (W4) | ☐ TBD | After min-instances deploy, run same script; paste into [docs/perf/baseline-w4.md](../perf/baseline-w4.md) |
+
+## Verify commands
+
+```bash
+export ASTRO_EPHE_PATH=./ephe/de440.bsp
+cargo test --workspace
+
+# Provenance (local)
+cargo run -p astro-api &
+curl -sS http://127.0.0.1:3000/provenance | jq .
+curl -sSI http://127.0.0.1:3000/provenance | grep -i cache-control
+
+# Synthetic chart (prod monitor script)
+export ASTRO_API_BASE_URL="https://your-cloud-run-url"
+export ASTRO_API_KEY="your-key"
+./scripts/monitoring/synthetic-chart-sidereal.sh
+
+# Horizons station regression (CI parity)
+cargo test -p astro-core outer_planet_stations -- --nocapture
+```
+
+## p95 baseline (fill when run)
+
+1. Set `ASTRO_API_BASE_URL` and `ASTRO_API_KEY` per [docs/deploy.md](../deploy.md).
+2. Run `./scripts/load/baseline-chart-sidereal.sh`.
+3. Copy p50/p95/p99 and error rate into [baseline-w2.md](../perf/baseline-w2.md) and [baseline-w4.md](../perf/baseline-w4.md).
+4. Query template: [docs/runbooks/queries/latency_p95.sql](queries/latency_p95.sql).

--- a/docs/runbooks/queries/latency_p95.sql
+++ b/docs/runbooks/queries/latency_p95.sql
@@ -1,0 +1,36 @@
+-- Astro engine latency percentiles from Cloud Logging → BigQuery export.
+-- Replace PROJECT_ID with your GCP project (see docs/runbooks/observability.md).
+-- Table wildcard: astro_engine_logs.run_googleapis_com_stdout_*
+
+-- Query 1: api_usage latency percentiles per path (last 24h)
+SELECT
+  jsonPayload.path AS path,
+  COUNT(*) AS request_count,
+  APPROX_QUANTILES(CAST(jsonPayload.latency_ms AS INT64), 100)[OFFSET(50)] AS p50_ms,
+  APPROX_QUANTILES(CAST(jsonPayload.latency_ms AS INT64), 100)[OFFSET(95)] AS p95_ms,
+  APPROX_QUANTILES(CAST(jsonPayload.latency_ms AS INT64), 100)[OFFSET(99)] AS p99_ms
+FROM
+  `PROJECT_ID.astro_engine_logs.run_googleapis_com_stdout_*`
+WHERE
+  timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+  AND jsonPayload.message = 'api_usage'
+  -- AND jsonPayload.path = '/chart/sidereal'
+GROUP BY
+  path
+ORDER BY
+  request_count DESC;
+
+-- Query 2: slo_breach counts per path (last 24h)
+SELECT
+  jsonPayload.path AS path,
+  COUNT(*) AS slo_breach_count
+FROM
+  `PROJECT_ID.astro_engine_logs.run_googleapis_com_stdout_*`
+WHERE
+  timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 24 HOUR)
+  AND jsonPayload.message = 'slo_breach'
+  AND jsonPayload.slo_breach = TRUE
+GROUP BY
+  path
+ORDER BY
+  slo_breach_count DESC;

--- a/docs/runbooks/reliability-min-instances.md
+++ b/docs/runbooks/reliability-min-instances.md
@@ -1,0 +1,47 @@
+# Cloud Run min-instances=1 (reliability)
+
+Production should run with **one warm instance** to avoid cold-start p95 spikes. Do **not** set `min-instances=2` without product sign-off. Do not use Spot / preemptible for this service.
+
+## Canonical deploy manifest
+
+| File | Role |
+| --- | --- |
+| [`deploy/cloudrun/service.yaml`](../../deploy/cloudrun/service.yaml) | **Canonical** — used by [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml) and [`cloudbuild.yaml`](../../cloudbuild.yaml) (`minScale: "1"`). |
+| [`deploy/cloud_run.yaml`](../../deploy/cloud_run.yaml) | Alternate / hand-deploy template (`astro-engine` name, 2 CPU / 2Gi); aligned to `minScale: "1"` for parity. |
+
+## Apply min-instances=1 (operator)
+
+Replace `SERVICE`, `REGION`, and `PROJECT` before running. **Do not run in production without explicit approval.**
+
+```bash
+gcloud run services update astro-api \
+  --project=PROJECT \
+  --region=asia-south1 \
+  --min-instances=1 \
+  --max-instances=10 \
+  --no-cpu-throttling
+```
+
+Or patch the Knative annotation on the next manifest deploy:
+
+```yaml
+autoscaling.knative.dev/minScale: "1"
+autoscaling.knative.dev/maxScale: "10"
+```
+
+## Verify warm instance
+
+After deploy, under steady `GET /health` traffic (or light authenticated chart traffic):
+
+1. Scrape `GET /metrics` twice, 30s apart, with `Authorization: Bearer $METRICS_TOKEN`.
+2. Confirm `astro_kernel_load_seconds` does **not** increment on every request after the first warm-up window.
+3. Compare p95 on `POST /chart/sidereal` against [baseline-w4.md](../perf/baseline-w4.md) (min=1 era) vs [baseline-w2.md](../perf/baseline-w2.md) (min=0 era).
+
+## Cost note
+
+`min-instances=1` is approved for production stability. Rolling back to `minScale: "0"` is an emergency cost cut only — expect cold-start regression on p95 (see [cold-start-w2.md](../perf/cold-start-w2.md)).
+
+## Related
+
+- [deploy.md](../deploy.md) — env vars including `METRICS_TOKEN`
+- [oncall.md](oncall.md) — rollback and escalation

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/scripts/gcp/create-log-sink.sh
+++ b/scripts/gcp/create-log-sink.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Logging → BigQuery sink for astro-api Cloud Run logs.
+# Requires: gcloud, bq; authenticated with permissions to create sinks and datasets.
+set -euo pipefail
+
+: "${GCP_PROJECT:?Set GCP_PROJECT to your GCP project id}"
+
+BQ_DATASET="${BQ_DATASET:-astro_engine_logs}"
+BQ_LOCATION="${BQ_LOCATION:-asia-south1}"
+CLOUD_RUN_SERVICE="${CLOUD_RUN_SERVICE:-astro-api}"
+SINK_ID="${SINK_ID:-astro-api-logs-to-bq}"
+
+LOG_FILTER=$'resource.type="cloud_run_revision"\nresource.labels.service_name="'"${CLOUD_RUN_SERVICE}"'"'
+
+echo "Project: ${GCP_PROJECT}"
+echo "Dataset: ${BQ_DATASET} (${BQ_LOCATION})"
+echo "Service filter: ${CLOUD_RUN_SERVICE}"
+echo "Sink: ${SINK_ID}"
+
+if ! bq show --project_id="${GCP_PROJECT}" "${BQ_DATASET}" >/dev/null 2>&1; then
+  echo "Creating BigQuery dataset ${BQ_DATASET}..."
+  bq --location="${BQ_LOCATION}" mk \
+    --dataset \
+    --description="Astro engine Cloud Run structured logs" \
+    "${GCP_PROJECT}:${BQ_DATASET}"
+else
+  echo "Dataset ${BQ_DATASET} already exists."
+fi
+
+DESTINATION="bigquery.googleapis.com/projects/${GCP_PROJECT}/datasets/${BQ_DATASET}"
+
+if gcloud logging sinks describe "${SINK_ID}" --project="${GCP_PROJECT}" >/dev/null 2>&1; then
+  echo "Updating existing sink ${SINK_ID}..."
+  gcloud logging sinks update "${SINK_ID}" \
+    --project="${GCP_PROJECT}" \
+    --log-filter="${LOG_FILTER}"
+else
+  echo "Creating sink ${SINK_ID}..."
+  gcloud logging sinks create "${SINK_ID}" "${DESTINATION}" \
+    --project="${GCP_PROJECT}" \
+    --log-filter="${LOG_FILTER}" \
+    --use-partitioned-tables
+fi
+
+SINK_WRITER="$(gcloud logging sinks describe "${SINK_ID}" \
+  --project="${GCP_PROJECT}" \
+  --format='value(writerIdentity)')"
+echo ""
+echo "Sink writer identity: ${SINK_WRITER}"
+echo "Grant roles/bigquery.dataEditor on dataset ${BQ_DATASET} if not already granted."
+echo ""
+echo "Query table prefix:"
+echo "  ${GCP_PROJECT}.${BQ_DATASET}.run_googleapis_com_stdout_*"

--- a/scripts/load/baseline-chart-sidereal.sh
+++ b/scripts/load/baseline-chart-sidereal.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Load test: 50 RPS for 5 minutes against POST /chart/sidereal with rotating birth fixtures.
+# Requires ASTRO_API_BASE_URL and ASTRO_API_KEY (see docs/deploy.md).
+
+set -euo pipefail
+
+BASE_URL="${ASTRO_API_BASE_URL:-}"
+API_KEY="${ASTRO_API_KEY:-}"
+DURATION="${LOAD_DURATION:-5m}"
+RATE="${LOAD_RATE:-50}"
+
+if [[ -z "${BASE_URL}" || -z "${API_KEY}" ]]; then
+  cat <<'EOF'
+Sprint 2 baseline load test — environment not configured.
+
+Set:
+  export ASTRO_API_BASE_URL="https://your-cloud-run-url"   # no trailing slash
+  export ASTRO_API_KEY="your-valid-key"                    # from VALID_API_KEYS
+
+Optional:
+  export LOAD_RATE=50          # requests per second (default 50)
+  export LOAD_DURATION=5m      # duration (default 5m)
+
+Then re-run:
+  ./scripts/load/baseline-chart-sidereal.sh
+
+Do not run against production without explicit approval. Record results in docs/perf/baseline-w2.md.
+EOF
+  exit 0
+fi
+
+BASE_URL="${BASE_URL%/}"
+TARGET="${BASE_URL}/chart/sidereal"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "${FIXTURE_DIR}"' EXIT
+
+cat >"${FIXTURE_DIR}/delhi-1990.json" <<'JSON'
+{"datetime":{"kind":"utc","utc":"1990-05-17T04:30:00Z"},"geo":{"latitude_deg":28.6139,"longitude_deg":77.2090,"elevation_m":216.0},"ayanamsa":"lahiri","compact":true,"projection":"sidereal_only"}
+JSON
+
+cat >"${FIXTURE_DIR}/bangalore-2000.json" <<'JSON'
+{"datetime":{"kind":"utc","utc":"2000-01-01T12:00:00Z"},"geo":{"latitude_deg":12.9716,"longitude_deg":77.5946,"elevation_m":920.0},"ayanamsa":"lahiri","compact":true,"projection":"sidereal_only"}
+JSON
+
+cat >"${FIXTURE_DIR}/independence-1947.json" <<'JSON'
+{"datetime":{"kind":"utc","utc":"1947-08-15T00:00:00Z"},"geo":{"latitude_deg":12.9716,"longitude_deg":77.5946,"elevation_m":920.0},"ayanamsa":"lahiri","compact":true,"projection":"sidereal_only"}
+JSON
+
+cat >"${FIXTURE_DIR}/bangalore-1995.json" <<'JSON'
+{"datetime":{"kind":"utc","utc":"1995-08-12T09:00:00Z"},"geo":{"latitude_deg":12.9716,"longitude_deg":77.5946,"elevation_m":920.0},"ayanamsa":"lahiri","compact":true,"projection":"sidereal_only"}
+JSON
+
+echo "Target: POST ${TARGET}"
+echo "Rate: ${RATE} RPS for ${DURATION}"
+echo "Fixtures: ${FIXTURE_DIR}/*.json (rotating)"
+
+if command -v oha >/dev/null 2>&1; then
+  echo "Tool: oha"
+  # oha does not rotate bodies natively; run one fixture per time slice (4 × 75s ≈ 5m at 50 RPS).
+  SLICE_DURATION="${LOAD_SLICE_DURATION:-75s}"
+  for fixture in "${FIXTURE_DIR}"/*.json; do
+    name="$(basename "${fixture}" .json)"
+    echo "--- ${name} (${SLICE_DURATION} @ ${RATE} RPS) ---"
+    oha -n "${RATE}" -c 50 -z "${SLICE_DURATION}" \
+      -m POST \
+      -H "content-type: application/json" \
+      -H "x-api-key: ${API_KEY}" \
+      -d @"${fixture}" \
+      "${TARGET}" || true
+  done
+  echo "Aggregate p50/p95/p99 from oha output above into docs/perf/baseline-w2.md"
+  exit 0
+fi
+
+if command -v vegeta >/dev/null 2>&1; then
+  echo "Tool: vegeta"
+  TARGETS_FILE="${FIXTURE_DIR}/targets.txt"
+  : >"${TARGETS_FILE}"
+  for fixture in "${FIXTURE_DIR}"/*.json; do
+    body="$(tr -d '\n' <"${fixture}")"
+    printf 'POST %s\nContent-Type: application/json\nX-Api-Key: %s\n\n%s\n\n' \
+      "${TARGET}" "${API_KEY}" "${body}" >>"${TARGETS_FILE}"
+  done
+  vegeta attack -duration="${DURATION}" -rate="${RATE}" -targets="${TARGETS_FILE}" \
+    | tee "${FIXTURE_DIR}/vegeta.bin" \
+    | vegeta report -type=text
+  vegeta report -type="hist[0,50ms,100ms,200ms,500ms,1s,2s]" "${FIXTURE_DIR}/vegeta.bin"
+  echo "Copy p50/p95/p99 and error rate into docs/perf/baseline-w2.md"
+  exit 0
+fi
+
+cat <<'EOF'
+Neither `oha` nor `vegeta` is installed.
+
+Install one of:
+  brew install oha
+  brew install vegeta
+
+Or run manually, for example with vegeta:
+  export ASTRO_API_BASE_URL=...
+  export ASTRO_API_KEY=...
+  ./scripts/load/baseline-chart-sidereal.sh
+EOF
+exit 1

--- a/scripts/monitoring/synthetic-chart-sidereal.sh
+++ b/scripts/monitoring/synthetic-chart-sidereal.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Synthetic transaction: POST /chart/sidereal (Delhi 1990) and assert lagna longitude.
+# Suitable for cron, Cloud Scheduler → Cloud Run job, or CI smoke against staging/production.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+FIXTURE="${REPO_ROOT}/tests/golden/synthetic/delhi-1990-chart.json"
+
+BASE_URL="${ASTRO_API_BASE_URL:-}"
+API_KEY="${ASTRO_API_KEY:-}"
+TOLERANCE="${SYNTHETIC_TOLERANCE_DEG:-1e-6}"
+
+if [[ -z "${BASE_URL}" || -z "${API_KEY}" ]]; then
+  cat <<'EOF'
+Synthetic chart monitor — environment not configured.
+
+Set:
+  export ASTRO_API_BASE_URL="https://your-cloud-run-url"
+  export ASTRO_API_KEY="your-valid-key"
+
+Optional:
+  export SYNTHETIC_LAGNA_EXPECTED_DEG=275.1573701670353
+  export SYNTHETIC_TOLERANCE_DEG=1e-6
+
+Then re-run:
+  ./scripts/monitoring/synthetic-chart-sidereal.sh
+EOF
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "${FIXTURE}" ]]; then
+  echo "missing fixture: ${FIXTURE}" >&2
+  exit 1
+fi
+
+BASE_URL="${BASE_URL%/}"
+TARGET="${BASE_URL}/chart/sidereal"
+BODY="$(jq -c '.request' "${FIXTURE}")"
+EXPECTED="${SYNTHETIC_LAGNA_EXPECTED_DEG:-$(jq -r '.expected_lagna_sidereal_longitude_deg' "${FIXTURE}")}"
+EXPECTED_RASHI="$(jq -r '.expected_lagna_rashi' "${FIXTURE}")"
+
+RESPONSE="$(mktemp)"
+trap 'rm -f "${RESPONSE}"' EXIT
+
+HTTP_CODE="$(curl -sS -o "${RESPONSE}" -w '%{http_code}' \
+  -X POST "${TARGET}" \
+  -H "content-type: application/json" \
+  -H "x-api-key: ${API_KEY}" \
+  -d "${BODY}")"
+
+if [[ "${HTTP_CODE}" != "200" ]]; then
+  echo "synthetic chart: HTTP ${HTTP_CODE}" >&2
+  head -c 500 "${RESPONSE}" >&2 || true
+  exit 1
+fi
+
+ACTUAL="$(jq -r '.data.lagna.sidereal_longitude_deg' "${RESPONSE}")"
+RASHI="$(jq -r '.data.lagna.rashi' "${RESPONSE}")"
+
+if [[ "${RASHI}" != "${EXPECTED_RASHI}" ]]; then
+  echo "synthetic chart: lagna rashi mismatch (got ${RASHI}, expected ${EXPECTED_RASHI})" >&2
+  exit 1
+fi
+
+DELTA="$(awk -v a="${ACTUAL}" -v e="${EXPECTED}" -v t="${TOLERANCE}" \
+  'BEGIN { d = (a - e); if (d < 0) d = -d; if (d > t) exit 1; print d }')" || {
+  echo "synthetic chart: lagna longitude mismatch (got ${ACTUAL}, expected ${EXPECTED}, tolerance ${TOLERANCE})" >&2
+  exit 1
+}
+
+echo "synthetic chart ok: lagna_sidereal_longitude_deg=${ACTUAL} (delta=${DELTA} <= ${TOLERANCE}), rashi=${RASHI}"

--- a/scripts/ship-v0.18-pr-from-main.sh
+++ b/scripts/ship-v0.18-pr-from-main.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Lifts the dasha_v2 timeline + yogas scaffold off `phase0-observability-baseline`
+# onto a fresh branch from `main`. Runs everything UP TO `git commit`. Does not
+# commit. Does not push. Does run `cargo check` + `cargo test` and refuses to
+# proceed if either fails.
+#
+# Usage:  bash scripts/ship-v0.18-pr-from-main.sh
+#         bash scripts/ship-v0.18-pr-from-main.sh --dry-run
+#
+# What it does:
+#   1. Clears any stale .git/index.lock.
+#   2. Stashes the V0.18 work (4 modified + yogas/ + docs/engine/) with
+#      --include-untracked so the planning docs etc. ride along to be re-popped.
+#   3. Switches to `main`, pulls latest, creates v0.18-dasha-timeline-and-yogas.
+#   4. Pops the stash onto the new branch.
+#   5. Selectively `git add`s ONLY the six dasha_v2 + yogas paths. Leaves
+#      business-site/, AstroEngine_LaunchPlan.docx, etc. untracked.
+#   6. Runs `cargo check --workspace --all-features` and `cargo test --workspace
+#      --all-features`. Refuses to continue on red.
+#   7. Prints the staged diff so you can review before committing.
+
+set -euo pipefail
+
+DRY_RUN="${1:-}"
+ADD_CMD=( git add )
+[[ "${DRY_RUN}" == "--dry-run" ]] && ADD_CMD=( echo "(dry-run) would: git add" )
+
+# Mutates repo, index, or working tree. Skipped in --dry-run (print only).
+git_mutate() {
+  if [[ "${DRY_RUN}" == "--dry-run" ]]; then
+    printf "(dry-run) would:"
+    printf " %q" "$@"
+    printf "\n"
+    return 0
+  fi
+  "$@"
+}
+
+log() { printf "\n\033[1;36m▸ %s\033[0m\n" "$*"; }
+warn() { printf "\n\033[1;33m! %s\033[0m\n" "$*"; }
+die()  { printf "\n\033[1;31m✗ %s\033[0m\n" "$*" >&2; exit 1; }
+
+cd "$(git rev-parse --show-toplevel)"
+
+NEW_BRANCH="v0.18-dasha-timeline-and-yogas"
+SOURCE_BRANCH="phase0-observability-baseline"
+STASH_MSG="v0.18: dasha_v2 timeline + yogas scaffold"
+
+# ─── Step 1: lockfile + source-branch checks ─────────────────────────────────
+
+log "Step 1/7 — Lockfile + source-branch checks"
+
+if [[ -f ".git/index.lock" ]]; then
+  warn "Found stale .git/index.lock — removing."
+  git_mutate rm -f .git/index.lock
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${CURRENT_BRANCH}" != "${SOURCE_BRANCH}" ]]; then
+  warn "Expected to start on '${SOURCE_BRANCH}', currently on '${CURRENT_BRANCH}'."
+  warn "If your V0.18 work lives elsewhere, abort and rerun manually."
+  read -p "Continue anyway? [y/N] " yn
+  [[ "${yn}" =~ ^[Yy]$ ]] || die "Aborted by user."
+fi
+
+# Sanity-check that the expected modifications are present
+EXPECTED=(
+  crates/astro-api/src/lib.rs
+  crates/astro-vedic/src/dasha.rs
+  crates/astro-vedic/src/lib.rs
+  dist/openapi.json
+)
+for f in "${EXPECTED[@]}"; do
+  if ! git diff --name-only | grep -qx "$f"; then
+    warn "Expected modification not detected in working tree: $f"
+    warn "If you already committed it, this script may stage nothing meaningful."
+  fi
+done
+
+YOGA_DIR="crates/astro-vedic/src/yogas"
+if [[ ! -d "${YOGA_DIR}" ]]; then
+  die "Yoga scaffold directory ${YOGA_DIR}/ not found — aborting."
+fi
+
+# ─── Step 2: stash with untracked ────────────────────────────────────────────
+
+log "Step 2/7 — Stash V0.18 work (incl. untracked)"
+
+git_mutate git stash push --include-untracked --message "${STASH_MSG}"
+
+# ─── Step 3: switch to main + pull + new branch ──────────────────────────────
+
+log "Step 3/7 — Switch to main, pull, create ${NEW_BRANCH}"
+
+git_mutate git checkout main
+git_mutate git pull origin main --ff-only
+
+if git rev-parse --verify --quiet "${NEW_BRANCH}" >/dev/null; then
+  warn "Branch ${NEW_BRANCH} already exists. Checking out."
+  git_mutate git checkout "${NEW_BRANCH}"
+else
+  git_mutate git checkout -b "${NEW_BRANCH}"
+fi
+
+# ─── Step 4: pop the stash ───────────────────────────────────────────────────
+
+log "Step 4/7 — Pop the V0.18 stash"
+
+if [[ "${DRY_RUN}" == "--dry-run" ]]; then
+  echo "(dry-run) would: git stash pop"
+elif ! git stash pop; then
+  die "Stash pop failed — resolve conflicts manually, then run cargo check + test."
+fi
+
+# ─── Step 5: selective staging ───────────────────────────────────────────────
+
+log "Step 5/7 — Stage dasha_v2 + yogas paths only"
+
+V018_PATHS=(
+  crates/astro-api/src/lib.rs
+  crates/astro-vedic/src/dasha.rs
+  crates/astro-vedic/src/lib.rs
+  crates/astro-vedic/src/yogas
+  dist/openapi.json
+  docs/engine/yogas-roadmap.md
+)
+for p in "${V018_PATHS[@]}"; do
+  if [[ -e "$p" ]]; then
+    "${ADD_CMD[@]}" "$p"
+  else
+    warn "Expected path not present: $p"
+  fi
+done
+
+# ─── Step 6: cargo check + test ──────────────────────────────────────────────
+
+log "Step 6/7 — cargo check + cargo test (sandbox-free verification)"
+
+if [[ "${DRY_RUN}" != "--dry-run" ]]; then
+  cargo check --workspace --all-features
+  cargo test  --workspace --all-features --no-fail-fast
+fi
+
+# ─── Step 7: summary ─────────────────────────────────────────────────────────
+
+log "Step 7/7 — Staged-vs-unstaged summary"
+
+if [[ "${DRY_RUN}" == "--dry-run" ]]; then
+  echo
+  echo "(dry-run) Skipped staged/unstaged summary — no checkout, stash pop, or git add ran."
+  echo
+  log "Dry-run complete (no repo mutations)."
+  echo "Next: rerun without --dry-run, then follow the post-run steps."
+else
+  echo
+  echo "── STAGED for the v0.18 PR ──"
+  git diff --cached --stat | tail -40
+
+  echo
+  echo "── UNTRACKED / unstaged (left out by design: business-site/, planning docs, etc.) ──"
+  git status --short | grep -vE '^[AMRD] ' | head -40
+
+  echo
+  log "Done staging on branch ${NEW_BRANCH}."
+  echo
+  echo "Next:"
+  echo "  1. Review:    git diff --cached"
+  echo "  2. Commit:    use the message from your engine ship plan §2.7 (feat(engine v0.18): …)"
+  echo "  3. Push:      git push -u origin ${NEW_BRANCH}"
+  echo "  4. PR:        open a PR targeting main on GitHub"
+  echo
+  echo "Optional cleanup after the PR lands and the engine redeploys:"
+  echo "  cargo run --bin astro-api  &  # local engine"
+  echo "  curl -sS http://localhost:8080/openapi.json | jq . > dist/openapi.json"
+  echo "  git diff dist/openapi.json    # confirm the regenerated file matches your intent"
+fi

--- a/tests/golden/horizons_stations/jupiter.json
+++ b/tests/golden/horizons_stations/jupiter.json
@@ -1,0 +1,87 @@
+{
+  "body": "jupiter",
+  "horizons_target": "599",
+  "horizons_params": {
+    "quantities": "31",
+    "apparent": "airless",
+    "center": "500@399",
+    "ephem_type": "observer",
+    "ang_format": "deg",
+    "ref_system": "icrf",
+    "atmospheric_refraction": "no",
+    "gravitational_deflection": true,
+    "notes": "Observer-centered apparent ecliptic-of-date; matches tests/regression/manifest.json horizons_deflection_on group."
+  },
+  "fixtures": [
+    {
+      "utc": "2020-05-15T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2020-05-15 12:00'&STOP_TIME='2020-05-15 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2021-06-21T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2021-06-21 12:00'&STOP_TIME='2021-06-21 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2022-07-29T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2022-07-29 12:00'&STOP_TIME='2022-07-29 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2023-09-05T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2023-09-05 12:00'&STOP_TIME='2023-09-05 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2024-10-10T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2024-10-10 12:00'&STOP_TIME='2024-10-10 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2020-09-14T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2020-09-14 12:00'&STOP_TIME='2020-09-14 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2021-10-19T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2021-10-19 12:00'&STOP_TIME='2021-10-19 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2022-11-24T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2022-11-24 12:00'&STOP_TIME='2022-11-24 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2024-01-01T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2024-01-01 12:00'&STOP_TIME='2024-01-01 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2025-02-05T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='599'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2025-02-05 12:00'&STOP_TIME='2025-02-05 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    }
+  ]
+}

--- a/tests/golden/horizons_stations/saturn.json
+++ b/tests/golden/horizons_stations/saturn.json
@@ -1,0 +1,87 @@
+{
+  "body": "saturn",
+  "horizons_target": "699",
+  "horizons_params": {
+    "quantities": "31",
+    "apparent": "airless",
+    "center": "500@399",
+    "ephem_type": "observer",
+    "ang_format": "deg",
+    "ref_system": "icrf",
+    "atmospheric_refraction": "no",
+    "gravitational_deflection": true,
+    "notes": "Observer-centered apparent ecliptic-of-date; matches tests/regression/manifest.json horizons_deflection_on group."
+  },
+  "fixtures": [
+    {
+      "utc": "2020-05-12T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2020-05-12 12:00'&STOP_TIME='2020-05-12 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2021-05-24T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2021-05-24 12:00'&STOP_TIME='2021-05-24 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2022-06-05T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2022-06-05 12:00'&STOP_TIME='2022-06-05 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2023-06-18T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2023-06-18 12:00'&STOP_TIME='2023-06-18 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2024-06-30T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2024-06-30 12:00'&STOP_TIME='2024-06-30 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "negative",
+      "station_kind": "retrograde_entry",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2020-09-30T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2020-09-30 12:00'&STOP_TIME='2020-09-30 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2021-10-12T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2021-10-12 12:00'&STOP_TIME='2021-10-12 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2022-10-24T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2022-10-24 12:00'&STOP_TIME='2022-10-24 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2023-11-05T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2023-11-05 12:00'&STOP_TIME='2023-11-05 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    },
+    {
+      "utc": "2024-11-16T12:00:00Z",
+      "horizons_url": "https://ssd.jpl.nasa.gov/api/horizons.api?format=json&COMMAND='699'&CENTER='500@399'&EPHEM_TYPE=OBSERVER&QUANTITIES='31'&START_TIME='2024-11-16 12:00'&STOP_TIME='2024-11-16 12:00'&STEP_SIZE='1%20d'&APPARENT=AIRLESS&REF_SYSTEM=ICRF&ANG_FORMAT=DEG",
+      "expected_speed_sign": "positive",
+      "station_kind": "direct",
+      "tolerance_deg": 1e-7
+    }
+  ]
+}

--- a/tests/golden/synthetic/delhi-1990-chart.json
+++ b/tests/golden/synthetic/delhi-1990-chart.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "datetime": { "kind": "utc", "utc": "1990-05-17T04:30:00Z" },
+    "geo": {
+      "latitude_deg": 28.6139,
+      "longitude_deg": 77.209,
+      "elevation_m": 216.0
+    },
+    "ayanamsa": "lahiri",
+    "compact": true,
+    "projection": "sidereal_only"
+  },
+  "expected_lagna_sidereal_longitude_deg": 275.1573701670353,
+  "expected_lagna_rashi": "makara",
+  "tolerance_deg": 1e-6,
+  "notes": "Pinned with DE440 (ASTRO_BACKEND=de440). Delhi 1990-05-17T04:30:00Z; same body as scripts/load/baseline-chart-sidereal.sh delhi fixture."
+}

--- a/tests/support/de440_kernel.rs
+++ b/tests/support/de440_kernel.rs
@@ -26,8 +26,7 @@ pub fn require_de440_kernel() -> Option<PathBuf> {
         }
     } else {
         eprintln!(
-            "skipping DE440-backed test: ASTRO_EPHE_PATH is unset and fallback ephemeris file is missing at {}",
-            TEST_FALLBACK_EPHE_PATH
+            "skipping DE440-backed test: ASTRO_EPHE_PATH is unset and fallback ephemeris file is missing at {TEST_FALLBACK_EPHE_PATH}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Extended `GET /provenance` (additive fields, `Cache-Control: public, max-age=3600`)
- `ENGINE_SEMANTIC_VERSION = 0.18.0`
- Phase 0–1 observability: structured logs, SLO breach events, `GET /metrics` + `METRICS_TOKEN`
- Reliability: `minScale: 1`, multi-region uptime scripts, synthetic chart monitor
- Horizons Jupiter/Saturn station CI (`.github/workflows/horizons.yml`) + retrograde motion contract
- Operator docs: `docs/runbooks/phase1-checklist-evidence.md`, `docs/retros/phase1.md`

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (with `ASTRO_EPHE_PATH`)
- [ ] CI `horizons.yml` green (requires DE440 kernel fetch secrets)
- [ ] Operator post-merge: run `./scripts/load/baseline-chart-sidereal.sh` and fill `docs/perf/baseline-w2.md` / `baseline-w4.md`

## After merge
```bash
git tag -a v0.18.0 -m "Phase 1 close"
git push origin v0.18.0
```
Set `METRICS_TOKEN` on Cloud Run before Prometheus scrape.


Made with [Cursor](https://cursor.com)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/sanjeetvermayoungengine-maker/daanyam-astro-engine/pull/3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->